### PR TITLE
Fix TypeScript build: add vite/client types for ImportMeta.env

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["vite/client"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "scripts"]


### PR DESCRIPTION
tsconfig.app.json was missing "types": ["vite/client"], which provides the ImportMeta.env type declarations Vite injects at build time. Without it, tsc rejects import.meta.env usage in all screen files.

https://claude.ai/code/session_01GfiuHrvX7UmTJKsZULutDn