### PR TITLE
feat(setup): safe category removal — archive if referenced, remove if not

### DIFF
--- a/scripts/category-utils.ts
+++ b/scripts/category-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * category-utils.ts
+ *
+ * Pure helper functions for category lifecycle management.
+ * Kept in a standalone file so they can be unit-tested without
+ * importing setup-sheet.ts (which has side effects at module load time).
+ */
+
+export type CategoryRemovalAction = 'archive' | 'remove';
+
+export interface CategoryRemovalResult {
+  /** archive → set active:false in the sheet (transactions reference this category)
+   *  remove  → omit the row entirely (no transaction references, safe to drop) */
+  action: CategoryRemovalAction;
+  /** Human-readable explanation for the console log. */
+  reason: string;
+}
+
+/**
+ * Decide what to do with a category that was removed from categories.json
+ * but still exists as a row in the Budget sheet.
+ *
+ * Rules:
+ *   - transactionCount > 0 → archive (active:false). Deleting would orphan
+ *     historical transactions that reference this category name.
+ *   - transactionCount === 0 → remove cleanly. No data loss risk.
+ *
+ * Exported for unit testing — all logic is pure with no I/O.
+ */
+export function handleRemovedCategory(
+  categoryName: string,
+  transactionCount: number
+): CategoryRemovalResult {
+  if (transactionCount > 0) {
+    return {
+      action: 'archive',
+      reason: `referenced by ${transactionCount} transaction(s) — setting active:false to preserve history`,
+    };
+  }
+  return {
+    action: 'remove',
+    reason: 'no transaction references — safe to remove',
+  };
+}

--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -13,6 +13,7 @@ import * as fs from "fs";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import { google, sheets_v4 } from "googleapis";
+import { handleRemovedCategory } from "./category-utils";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -613,29 +614,73 @@ async function applyConditionalFormatting(
 
 // ─── Step: Seed Budget Categories ─────────────────────────────────────────────
 //
-// Strategy: clear rows 2–501 (category definition rows) and rewrite from
-// categories.json on every run. This is safe because:
-//   - Rows 2–501 are pure config — no financial data lives here.
-//   - Monthly assignment data lives at row 502+, referenced by category name
-//     string — completely untouched by this operation.
-// This ensures categories.json is the true single source of truth: no
-// accumulated test data, no stale rows, no drift from type/group changes.
+// Strategy: clear rows 2–501 and rewrite from categories.json on every run.
+// Before clearing, we check for categories that existed in the sheet but were
+// removed from categories.json. If any are referenced by transactions they are
+// archived (active:false) rather than deleted — preserving historical data
+// integrity. Categories with no transaction references are removed cleanly.
 
 async function seedBudgetCategories(
   sheets: sheets_v4.Sheets,
   sheetId: string,
-  categories: FlatCategory[]
+  newCategories: FlatCategory[]
 ): Promise<void> {
-  // Clear existing category rows (rows 2–501), leaving header row 1 intact
-  // and the monthly assignments section (502+) completely untouched.
+  // ── 1. Read current Budget category rows to detect removals ──────────────────
+  const existingRes = await sheets.spreadsheets.values.get({
+    spreadsheetId: sheetId,
+    range: "Budget!A2:G501",
+  });
+  const existingRows = existingRes.data.values ?? [];
+
+  // ── 2. Identify removed categories (in sheet now, absent from new JSON) ──────
+  const newNames = new Set(newCategories.map((c) => c.category));
+  const removedRows = existingRows.filter((r) => r[2] && !newNames.has(r[2]));
+
+  // ── 3. Count transaction references for each removed category ────────────────
+  //    Skip the Transactions read entirely if nothing was removed (common case).
+  const txCounts = new Map<string, number>();
+  if (removedRows.length > 0) {
+    // Read only the category column (K) — avoids pulling full transaction rows.
+    const txRes = await sheets.spreadsheets.values.get({
+      spreadsheetId: sheetId,
+      range: "Transactions!K2:K",
+    });
+    for (const row of txRes.data.values ?? []) {
+      const name = row[0] as string | undefined;
+      if (name) txCounts.set(name, (txCounts.get(name) ?? 0) + 1);
+    }
+  }
+
+  // ── 4. Decide archive vs remove for each removed category ────────────────────
+  const toArchive: FlatCategory[] = [];
+  for (const row of removedRows) {
+    const name = row[2] as string;
+    const txCount = txCounts.get(name) ?? 0;
+    const { action, reason } = handleRemovedCategory(name, txCount);
+
+    if (action === "archive") {
+      toArchive.push({
+        group: row[0] ?? "",
+        subgroup: row[1] ?? "",
+        category: name,
+        type: row[3] ?? "fluid",
+        template: parseFloat(row[4]) || 0,
+        sort_order: parseInt(row[5]) || 9999,
+        active: false,
+      });
+      log(`Budget seed: ⚠  archived "${name}" — ${reason}`);
+    } else {
+      log(`Budget seed: removed "${name}" — ${reason}`);
+    }
+  }
+
+  // ── 5. Clear rows 2–501 and rewrite: active categories + archived ones ───────
   await sheets.spreadsheets.values.clear({
     spreadsheetId: sheetId,
     range: "Budget!A2:G501",
   });
-  log(`Budget seed: cleared category rows 2–501`);
 
-  // Write all categories from JSON in sort_order
-  const rows = categories.map((c) => [
+  const allRows = [...newCategories, ...toArchive].map((c) => [
     c.group,
     c.subgroup,
     c.category,
@@ -649,10 +694,17 @@ async function seedBudgetCategories(
     spreadsheetId: sheetId,
     range: "Budget!A2",
     valueInputOption: "RAW",
-    requestBody: { values: rows },
+    requestBody: { values: allRows },
   });
 
-  log(`Budget seed: wrote ${categories.length} categories from categories.json`);
+  const archivedCount = toArchive.length;
+  const removedCount = removedRows.length - archivedCount;
+  log(
+    `Budget seed: wrote ${newCategories.length} active` +
+    (archivedCount ? `, ${archivedCount} archived` : "") +
+    (removedCount ? `, ${removedCount} removed` : "") +
+    " categories"
+  );
 }
 
 // ─── Step: Lock Budget category rows ─────────────────────────────────────────

--- a/tests/unit/category-utils.test.ts
+++ b/tests/unit/category-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { handleRemovedCategory } from '../../scripts/category-utils';
+
+describe('handleRemovedCategory', () => {
+  it('archives when transactionCount > 0', () => {
+    const result = handleRemovedCategory('Old Category', 5);
+    expect(result.action).toBe('archive');
+  });
+
+  it('removes cleanly when transactionCount === 0', () => {
+    const result = handleRemovedCategory('Old Category', 0);
+    expect(result.action).toBe('remove');
+  });
+
+  it('includes the transaction count in the archive reason', () => {
+    const result = handleRemovedCategory('Gym Membership', 12);
+    expect(result.reason).toContain('12');
+  });
+
+  it('treats exactly 1 transaction as requiring archive', () => {
+    expect(handleRemovedCategory('X', 1).action).toBe('archive');
+  });
+
+  it('reason string differs between archive and remove', () => {
+    const archive = handleRemovedCategory('X', 3);
+    const remove = handleRemovedCategory('X', 0);
+    expect(archive.reason).not.toBe(remove.reason);
+  });
+});


### PR DESCRIPTION
## Summary

- When a category is removed from `categories.json` and `setup-sheet` runs, it now checks for transaction references before deciding what to do
- **Has transactions** → set `active:false` in the Budget row (archived), log a warning with the count
- **No transactions** → remove cleanly, log info
- If no categories were removed, the Transactions tab is never read (skips the API call entirely — common case is zero removals)

## Why this matters

The clear-then-rewrite approach would silently drop a removed category even if 50 transactions pointed to it by name. Historical data would become uncategorized with no warning. This makes `setup-sheet` safe to run in any context.

## Implementation notes

- `scripts/category-utils.ts` — pure `handleRemovedCategory(name, txCount)` extracted into its own file so tests can import it without triggering `main()` side effects
- Reads only `Transactions!K` (the category column) when needed, not full rows
- Archived rows are written after active categories, preserving all existing field values

## Test plan

- [x] 43/43 unit tests passing locally including 5 new tests in `category-utils.test.ts`
- [x] CI passes on this PR
- [ ] Manual: remove a category from `categories.json` that has transactions → run `npm run setup:dev` → confirm row is still present with `active:FALSE` and a warning logged
- [x] Manual: remove a category with no transactions → run setup → confirm row is gone

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)