### PR TITLE
feat: implement sync-from-prod-to-dev (#41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,11 @@
 # ── Google Sheets backend (used by setup scripts) ─────────────────────────────
 
 # The ID of the Google Sheet (from the URL: /spreadsheets/d/<SHEET_ID>/edit)
-GOOGLE_SHEET_ID=your_sheet_id_here
+#GOOGLE_SHEET_ID is set to your dev sheet ID if this .env.development
+GOOGLE_SHEET_ID=your_env-specific_sheet_id_here
 GOOGLE_SERVICE_ACCOUNT_KEY_PATH=/Users/bob/Code/zero-based-budget-123456-4569fabc261e.json
+PROD_GOOGLE_SHEET_ID=your_prod_sheet_id
+DEV_GOOGLE_SHEET_ID=your_dev_sheet_id
 # Service account credentials (choose one):
 
 # Option A — Inline JSON key contents (recommended for cloud/CI environments).

--- a/scripts/sync-from-prod-to-dev.ts
+++ b/scripts/sync-from-prod-to-dev.ts
@@ -1,15 +1,247 @@
 /**
  * sync-from-prod-to-dev.ts
  *
- * Copies transaction and budget assignment data from the prod sheet to the dev
- * sheet so that integration tests run against a realistic dataset.
+ * Copies all meaningful data from the prod sheet to the dev sheet.
+ * Gives PR integration tests a realistic dataset without risking prod data.
+ * Safe to run multiple times — fully idempotent (wipe-and-rewrite each tab).
  *
- * Requires:
- *   GOOGLE_SERVICE_ACCOUNT_KEY  — service account JSON (inline)
- *   PROD_GOOGLE_SHEET_ID        — source sheet ID
- *   DEV_GOOGLE_SHEET_ID         — destination sheet ID
+ * What gets copied:
+ *   - Transactions tab (all rows)
+ *   - Budget tab (rows 2+ — row 1 contains a formula managed by setup:dev)
+ *   - Templates tab (all rows)
+ *   - Balance History (BTS) tab (all rows)
+ *   - YNAB_Plan_Import tab (all rows, if populated)
  *
- * TODO: implement in milestone M2 (tracked in issue #40 follow-up)
+ * What does NOT get copied:
+ *   - BankToSheets_Raw (BTS-owned)
+ *   - Reflect (formula-only charts/summaries)
+ *   - YNAB_Transactions_Import (reserved, empty)
+ *
+ * Usage:
+ *   npm run sync-from-prod-to-dev
+ *
+ * Required env vars (set in .env.development or as environment variables):
+ *   PROD_GOOGLE_SHEET_ID            — ID of the prod sheet to read from
+ *   DEV_GOOGLE_SHEET_ID             — ID of the dev sheet to write to
+ *                                     (falls back to GOOGLE_SHEET_ID if not set)
+ *   GOOGLE_SERVICE_ACCOUNT_KEY      — inline JSON credentials (recommended for CI)
+ *   GOOGLE_SERVICE_ACCOUNT_KEY_PATH — path to key file (local dev alternative)
  */
 
-console.log("sync-from-prod-to-dev: not yet implemented — skipping");
+import * as path from 'path';
+import * as fs from 'fs';
+import { google, sheets_v4 } from 'googleapis';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type AuthConfig =
+  | { kind: 'keyFile'; keyPath: string }
+  | { kind: 'credentials'; credentials: object };
+
+interface EnvConfig {
+  prodSheetId: string;
+  devSheetId: string;
+  authConfig: AuthConfig;
+}
+
+export interface TabSpec {
+  tabName: string;
+  readRange: string;
+  clearRange: string;
+  writeStartRange: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// Tabs to copy from prod to dev, in order
+const TABS_TO_COPY = [
+  'Transactions',
+  'Budget',
+  'Templates',
+  'Balance History (BTS)',
+  'YNAB_Plan_Import',
+];
+
+export const TABS_TO_SKIP = new Set([
+  'BankToSheets_Raw',
+  'Reflect',
+  'YNAB_Transactions_Import',
+]);
+
+// ─── Pure functions (exported for unit testing) ────────────────────────────────
+
+/**
+ * Filter a list of tab names to only those we should copy.
+ * Order follows TABS_TO_COPY definition; missing tabs are silently skipped.
+ */
+export function selectTabsToCopy(allTabNames: string[]): string[] {
+  const available = new Set(allTabNames);
+  return TABS_TO_COPY.filter((t) => available.has(t) && !TABS_TO_SKIP.has(t));
+}
+
+/**
+ * Return the range spec for a given tab.
+ * Budget tab reads from A2 (row 1 holds a ReadyToAssign formula managed by setup:dev).
+ * All other tabs do a full wipe-and-rewrite from row 1.
+ */
+export function buildTabSpec(tabName: string): TabSpec {
+  // Quote tab names that contain spaces so the Sheets API range is valid
+  const q = tabName.includes(' ') ? `'${tabName}'` : tabName;
+  if (tabName === 'Budget') {
+    return {
+      tabName,
+      readRange: `${q}!A2:ZZ`,
+      clearRange: `${q}!A2:ZZ`,
+      writeStartRange: `${q}!A2`,
+    };
+  }
+  return {
+    tabName,
+    readRange: `${q}!A1:ZZ`,
+    clearRange: `${q}!A:ZZ`,
+    writeStartRange: `${q}!A1`,
+  };
+}
+
+// ─── Environment loading ──────────────────────────────────────────────────────
+
+function loadEnv(): EnvConfig {
+  // Load .env.development if present — provides auth + sheet IDs for local dev
+  const envPath = path.resolve(process.cwd(), '.env.development');
+  if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf-8').split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const val = trimmed.slice(eq + 1).trim();
+      if (!process.env[key]) process.env[key] = val;
+    }
+    log('Loaded env from .env.development');
+  }
+
+  const prodSheetId = process.env.PROD_GOOGLE_SHEET_ID;
+  if (!prodSheetId || prodSheetId === 'your_sheet_id_here') {
+    bail('PROD_GOOGLE_SHEET_ID not set. Add it to .env.development or set it as an environment variable.');
+  }
+
+  // DEV_GOOGLE_SHEET_ID falls back to GOOGLE_SHEET_ID (used by the other dev scripts)
+  const devSheetId = process.env.DEV_GOOGLE_SHEET_ID ?? process.env.GOOGLE_SHEET_ID;
+  if (!devSheetId || devSheetId === 'your_sheet_id_here') {
+    bail('DEV_GOOGLE_SHEET_ID not set. Add it to .env.development or set it as an environment variable.');
+  }
+
+  const inlineKey = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  const keyFilePath = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_PATH;
+  let authConfig: AuthConfig;
+
+  if (inlineKey) {
+    let credentials: object;
+    try { credentials = JSON.parse(inlineKey); } catch {
+      bail('GOOGLE_SERVICE_ACCOUNT_KEY is set but is not valid JSON.');
+    }
+    authConfig = { kind: 'credentials', credentials: credentials! };
+  } else if (keyFilePath) {
+    const resolved = path.resolve(process.cwd(), keyFilePath);
+    if (!fs.existsSync(resolved)) bail(`Key file not found: ${resolved}`);
+    authConfig = { kind: 'keyFile', keyPath: resolved };
+  } else {
+    bail('No credentials found. Set GOOGLE_SERVICE_ACCOUNT_KEY or GOOGLE_SERVICE_ACCOUNT_KEY_PATH.');
+  }
+
+  return { prodSheetId: prodSheetId!, devSheetId: devSheetId!, authConfig: authConfig! };
+}
+
+// ─── Sheet operations ─────────────────────────────────────────────────────────
+
+/** Copy one tab from prod to dev: read → clear → write. Returns row count written. */
+async function copyTab(
+  sheets: sheets_v4.Sheets,
+  prodSheetId: string,
+  devSheetId: string,
+  spec: TabSpec
+): Promise<number> {
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: prodSheetId,
+    range: spec.readRange,
+  });
+  const rows = res.data.values ?? [];
+
+  await sheets.spreadsheets.values.clear({
+    spreadsheetId: devSheetId,
+    range: spec.clearRange,
+  });
+
+  if (rows.length > 0) {
+    await sheets.spreadsheets.values.update({
+      spreadsheetId: devSheetId,
+      range: spec.writeStartRange,
+      valueInputOption: 'RAW',
+      requestBody: { values: rows },
+    });
+  }
+
+  return rows.length;
+}
+
+// ─── Logging & Error Helpers ──────────────────────────────────────────────────
+
+function log(msg: string): void {
+  console.log(`  ✓ ${msg}`);
+}
+
+function bail(msg: string): never {
+  console.error(`\n  ✗ Error: ${msg}\n`);
+  process.exit(1);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('\n── Zero Budget: Sync Prod → Dev ────────────────────────────\n');
+
+  const { prodSheetId, devSheetId, authConfig } = loadEnv();
+
+  const auth = new google.auth.GoogleAuth({
+    ...(authConfig.kind === 'keyFile'
+      ? { keyFile: authConfig.keyPath }
+      : { credentials: authConfig.credentials }),
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  const sheets = google.sheets({ version: 'v4', auth });
+  log('Authenticated with Google Sheets API');
+
+  // Fail fast: verify prod is accessible before touching dev
+  let prodTabNames: string[];
+  try {
+    const res = await sheets.spreadsheets.get({
+      spreadsheetId: prodSheetId,
+      fields: 'sheets(properties(title))',
+    });
+    prodTabNames = (res.data.sheets ?? [])
+      .map((s) => s.properties?.title ?? '')
+      .filter(Boolean);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    bail(`Cannot access prod sheet (${prodSheetId}): ${msg}`);
+  }
+
+  const tabsToCopy = selectTabsToCopy(prodTabNames!);
+  log(`Tabs to copy: ${tabsToCopy.join(', ')}`);
+
+  for (const tabName of tabsToCopy) {
+    const spec = buildTabSpec(tabName);
+    const count = await copyTab(sheets, prodSheetId, devSheetId, spec);
+    log(`${tabName}: copied ${count} row(s)`);
+  }
+
+  console.log('\n── Done ────────────────────────────────────────────────────\n');
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('\n  ✗ Unexpected error:', err.message ?? err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/sync-from-prod-to-dev.test.ts
+++ b/tests/unit/sync-from-prod-to-dev.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectTabsToCopy,
+  buildTabSpec,
+  TABS_TO_SKIP,
+} from '../../scripts/sync-from-prod-to-dev';
+
+// ─── selectTabsToCopy ─────────────────────────────────────────────────────────
+
+describe('selectTabsToCopy', () => {
+  it('returns all known copyable tabs when all are present', () => {
+    const all = [
+      'Transactions',
+      'Budget',
+      'Templates',
+      'Balance History (BTS)',
+      'YNAB_Plan_Import',
+      'BankToSheets_Raw',
+      'Reflect',
+      'YNAB_Transactions_Import',
+    ];
+    expect(selectTabsToCopy(all)).toEqual([
+      'Transactions',
+      'Budget',
+      'Templates',
+      'Balance History (BTS)',
+      'YNAB_Plan_Import',
+    ]);
+  });
+
+  it('excludes every tab in TABS_TO_SKIP', () => {
+    expect(selectTabsToCopy([...TABS_TO_SKIP])).toEqual([]);
+  });
+
+  it('silently skips tabs not present in the sheet', () => {
+    expect(selectTabsToCopy(['Transactions', 'Budget'])).toEqual(['Transactions', 'Budget']);
+  });
+
+  it('preserves TABS_TO_COPY order regardless of input order', () => {
+    const result = selectTabsToCopy(['Budget', 'YNAB_Plan_Import', 'Transactions']);
+    expect(result).toEqual(['Transactions', 'Budget', 'YNAB_Plan_Import']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(selectTabsToCopy([])).toEqual([]);
+  });
+});
+
+// ─── buildTabSpec ─────────────────────────────────────────────────────────────
+
+describe('buildTabSpec', () => {
+  it('Transactions: full wipe-and-rewrite from row 1', () => {
+    const spec = buildTabSpec('Transactions');
+    expect(spec.readRange).toBe('Transactions!A1:ZZ');
+    expect(spec.clearRange).toBe('Transactions!A:ZZ');
+    expect(spec.writeStartRange).toBe('Transactions!A1');
+  });
+
+  it('Budget: reads and writes from row 2, skipping the formula in row 1', () => {
+    const spec = buildTabSpec('Budget');
+    expect(spec.readRange).toBe('Budget!A2:ZZ');
+    expect(spec.clearRange).toBe('Budget!A2:ZZ');
+    expect(spec.writeStartRange).toBe('Budget!A2');
+  });
+
+  it('Templates: full wipe-and-rewrite from row 1', () => {
+    const spec = buildTabSpec('Templates');
+    expect(spec.readRange).toBe('Templates!A1:ZZ');
+    expect(spec.clearRange).toBe('Templates!A:ZZ');
+    expect(spec.writeStartRange).toBe('Templates!A1');
+  });
+
+  it('Balance History (BTS): quotes tab name correctly for Sheets range syntax', () => {
+    const spec = buildTabSpec('Balance History (BTS)');
+    expect(spec.readRange).toBe("'Balance History (BTS)'!A1:ZZ");
+    expect(spec.clearRange).toBe("'Balance History (BTS)'!A:ZZ");
+    expect(spec.writeStartRange).toBe("'Balance History (BTS)'!A1");
+  });
+
+  it('YNAB_Plan_Import: full wipe-and-rewrite from row 1', () => {
+    const spec = buildTabSpec('YNAB_Plan_Import');
+    expect(spec.readRange).toBe('YNAB_Plan_Import!A1:ZZ');
+    expect(spec.clearRange).toBe('YNAB_Plan_Import!A:ZZ');
+    expect(spec.writeStartRange).toBe('YNAB_Plan_Import!A1');
+  });
+
+  it('tabName is preserved on the spec', () => {
+    expect(buildTabSpec('Transactions').tabName).toBe('Transactions');
+    expect(buildTabSpec('Budget').tabName).toBe('Budget');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the no-op stub in `scripts/sync-from-prod-to-dev.ts` with a full implementation
- Copies Transactions, Budget (rows 2+), Templates, Balance History (BTS), and YNAB_Plan_Import from prod → dev using wipe-and-rewrite per tab
- Skips BankToSheets_Raw (BTS-owned), Reflect (formula-only), and YNAB_Transactions_Import (reserved)
- Fails fast with a clear error if the prod sheet is unreachable — dev is never touched in that case
- Budget row 1 is intentionally excluded (holds the `ReadyToAssign` formula set by `setup:dev`)
- `DEV_GOOGLE_SHEET_ID` falls back to `GOOGLE_SHEET_ID` so existing local `.env.development` files work without changes

## What a reviewer should know

The PR pipeline in `pr.yml` was already wired up for this script (lines 63–68) and `package.json` already had the `sync-from-prod-to-dev` entry — no workflow changes needed.

Two pure functions are exported for testability: `selectTabsToCopy` (filters tab list to only the ones we copy, in the canonical order) and `buildTabSpec` (returns read/clear/write ranges per tab, with the Budget special-case baked in).

## Test plan

- [x] `npm test` — 101 unit tests pass, including 11 new ones for this script
- [x] Manual: run `npm run sync-from-prod-to-dev` locally with `PROD_GOOGLE_SHEET_ID` + `DEV_GOOGLE_SHEET_ID` set and confirm dev sheet data matches prod

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)