### PR TITLE
feat: Plan — tap category to assign money (#4)

### DIFF
--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -120,11 +120,21 @@ const TEMPLATES_COLUMNS = [
   "amount",
 ];
 
+const BUDGET_LOG_COLUMNS = [
+  "timestamp",
+  "month",
+  "category",
+  "amount",
+  "change_type",
+  "note",
+];
+
 const TABS_IN_ORDER = [
   "Transactions",
   "Budget",
   "Templates",
   "Reflect",
+  "Budget_Log",
   "Transactions (BTS)",
   "Balance History (BTS)",
   "YNAB_Plan_Import",
@@ -136,7 +146,7 @@ const HEADER_BG_COLOR = { red: 0.29, green: 0.525, blue: 0.91 };
 const HEADER_FG_COLOR = { red: 1, green: 1, blue: 1 };
 
 // Sheet schema version — increment when structure changes
-const SHEET_VERSION = 3;
+const SHEET_VERSION = 4;
 
 // ─── Environment Loading ───────────────────────────────────────────────────────
 
@@ -354,6 +364,7 @@ async function writeHeaders(
     { title: "Transactions", columns: TRANSACTIONS_COLUMNS, headerRow: 1 },
     { title: "Budget", columns: BUDGET_CATEGORY_COLUMNS, headerRow: BUDGET_CATEGORIES_HEADER_ROW },
     { title: "Templates", columns: TEMPLATES_COLUMNS, headerRow: 1 },
+    { title: "Budget_Log", columns: BUDGET_LOG_COLUMNS, headerRow: 1 },
   ];
 
   const formatRequests: sheets_v4.Schema$Request[] = [];

--- a/src/api/budget.ts
+++ b/src/api/budget.ts
@@ -109,6 +109,24 @@ export async function upsertAssignment(
   }
 }
 
+/**
+ * Append an entry to the Budget_Log tab.
+ * @param amount — delta (new assigned minus previous), not absolute value
+ * @param change_type — 'manual' | 'template' | 'move_from:X' | 'move_to:X'
+ */
+export async function appendLogEntry(
+  client: SheetsClient,
+  month: string,
+  category: string,
+  amount: number,
+  change_type: string,
+  note = ''
+): Promise<void> {
+  await client.appendValues('Budget_Log!A2', [
+    [new Date().toISOString(), month, category, amount, change_type, note],
+  ]);
+}
+
 // ─── View builders ────────────────────────────────────────────────────────────
 
 /**

--- a/src/app.css
+++ b/src/app.css
@@ -137,12 +137,53 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .budget-row {
   display: flex; align-items: center; padding: 9px 16px;
   border-bottom: 1px solid var(--border); background: var(--surface);
+  width: 100%; text-align: left; font: inherit; border-left: none; border-right: none; border-top: none;
+  cursor: pointer;
 }
 .budget-row.overspent { background: #fff5f4; }
 .budget-row:hover { background: #f8faff; }
 
 .col-name { flex: 1; font-size: 14px; }
 .col-num { width: 80px; text-align: right; font-size: 14px; font-variant-numeric: tabular-nums; }
+
+/* ── Assignment bottom sheet ──────────────────────────────────────────────── */
+.assign-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,.45);
+  z-index: 200; display: flex; align-items: flex-end;
+}
+.assign-sheet {
+  width: 100%; background: var(--surface); border-radius: 16px 16px 0 0;
+  padding: 12px 20px 40px; box-shadow: 0 -4px 24px rgba(0,0,0,.14);
+}
+.assign-sheet-handle {
+  width: 40px; height: 4px; border-radius: 2px; background: var(--border);
+  margin: 0 auto 20px;
+}
+.assign-sheet-title {
+  font-size: 16px; font-weight: 700; margin-bottom: 20px; text-align: center;
+}
+.assign-label {
+  display: block; font-size: 12px; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: .5px; margin-bottom: 8px;
+}
+.assign-input {
+  width: 100%; font-size: 28px; font-weight: 700; text-align: center;
+  border: 2px solid var(--accent); border-radius: 10px;
+  padding: 12px; background: var(--bg); color: var(--text);
+  outline: none; font-variant-numeric: tabular-nums;
+}
+.assign-input:focus { border-color: var(--accent-dark); }
+.assign-save-error {
+  margin-top: 8px; font-size: 13px; color: var(--negative); text-align: center;
+}
+.assign-sheet-actions {
+  display: flex; gap: 12px; margin-top: 20px;
+}
+.assign-sheet-actions > button { flex: 1; }
+.btn-secondary {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border);
+  border-radius: 10px; padding: 12px 24px; font-size: 15px; font-weight: 600; cursor: pointer;
+}
 
 /* ── Accounts screen ──────────────────────────────────────────────────────── */
 .accounts-total {

--- a/src/screens/Plan.tsx
+++ b/src/screens/Plan.tsx
@@ -2,9 +2,16 @@ import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { useSheetSync } from '../hooks/useSheetSync';
 import { SheetsClient } from '../api/client';
-import { fetchBudgetCategories, fetchMonthAssignments, buildGroupedBudget, fetchReadyToAssign } from '../api/budget';
+import {
+  fetchBudgetCategories,
+  fetchMonthAssignments,
+  buildGroupedBudget,
+  fetchReadyToAssign,
+  upsertAssignment,
+  appendLogEntry,
+} from '../api/budget';
 import { fetchTransactions, computeCategoryActivity } from '../api/transactions';
-import { GroupedBudget } from '../types';
+import { GroupedBudget, BudgetAssignment, CategoryWithActivity } from '../types';
 
 const SHEET_ID = import.meta.env.VITE_GOOGLE_SHEET_ID as string;
 
@@ -21,14 +28,24 @@ function fmt(n: number): string {
   });
 }
 
+interface EditState {
+  cat: CategoryWithActivity;
+  existing: BudgetAssignment | undefined;
+  inputValue: string;
+  saving: boolean;
+  saveError: string | null;
+}
+
 export default function Plan() {
   const { token } = useAuth();
   const revision = useSheetSync(token);
   const [month, setMonth] = useState(() => toYYYYMM(new Date()));
   const [groups, setGroups] = useState<GroupedBudget[]>([]);
+  const [assignments, setAssignments] = useState<BudgetAssignment[]>([]);
   const [readyToAssign, setReadyToAssign] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editState, setEditState] = useState<EditState | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -37,13 +54,14 @@ export default function Plan() {
     setError(null);
 
     try {
-      const [categories, assignments, transactions] = await Promise.all([
+      const [cats, rawAssignments, txns] = await Promise.all([
         fetchBudgetCategories(client),
         fetchMonthAssignments(client, month),
         fetchTransactions(client, { month }),
       ]);
-      const activityMap = computeCategoryActivity(transactions);
-      setGroups(buildGroupedBudget(categories, assignments, activityMap));
+      const activityMap = computeCategoryActivity(txns);
+      setAssignments(rawAssignments);
+      setGroups(buildGroupedBudget(cats, rawAssignments, activityMap));
       setReadyToAssign(await fetchReadyToAssign(client));
     } catch (e) {
       setError((e as Error).message);
@@ -57,6 +75,38 @@ export default function Plan() {
   const totalAssigned = groups.reduce((s, g) => s + g.totalAssigned, 0);
   const totalActivity = groups.reduce((s, g) => s + g.totalActivity, 0);
   const totalAvailable = groups.reduce((s, g) => s + g.totalAvailable, 0);
+
+  const handleRowClick = (cat: CategoryWithActivity) => {
+    const existing = assignments.find((a) => a.category === cat.category);
+    setEditState({
+      cat,
+      existing,
+      inputValue: cat.assigned === 0 ? '' : String(cat.assigned),
+      saving: false,
+      saveError: null,
+    });
+  };
+
+  const handleCancel = () => setEditState(null);
+
+  const handleSave = async () => {
+    if (!editState || !token) return;
+    const amount = parseFloat(editState.inputValue) || 0;
+    const { cat, existing } = editState;
+    setEditState((prev) => prev ? { ...prev, saving: true, saveError: null } : null);
+    try {
+      const client = new SheetsClient(SHEET_ID, token);
+      await upsertAssignment(client, month, cat.category, amount, existing);
+      const delta = amount - (existing?.assigned ?? 0);
+      await appendLogEntry(client, month, cat.category, delta, 'manual');
+      setEditState(null);
+      await load();
+    } catch (e) {
+      setEditState((prev) =>
+        prev ? { ...prev, saving: false, saveError: (e as Error).message } : null
+      );
+    }
+  };
 
   return (
     <div className="screen plan-screen">
@@ -122,9 +172,11 @@ export default function Plan() {
                     <div className="subgroup-header">{subgroupName}</div>
                   )}
                   {categories.map((cat) => (
-                    <div
+                    <button
                       key={cat.category}
+                      type="button"
                       className={`budget-row${cat.available < 0 ? ' overspent' : ''}`}
+                      onClick={() => handleRowClick(cat)}
                     >
                       <span className="col-name">{cat.category}</span>
                       <span className="col-num">{fmt(cat.assigned)}</span>
@@ -132,7 +184,7 @@ export default function Plan() {
                       <span className={`col-num${cat.available < 0 ? ' negative' : ''}`}>
                         {fmt(cat.available)}
                       </span>
-                    </div>
+                    </button>
                   ))}
                 </div>
               ))}
@@ -143,6 +195,50 @@ export default function Plan() {
             <div className="state-msg">No categories found. Run <code>npm run setup:dev</code> first.</div>
           )}
         </>
+      )}
+
+      {editState && (
+        <div className="assign-overlay" onClick={handleCancel}>
+          <div className="assign-sheet" onClick={(e) => e.stopPropagation()}>
+            <div className="assign-sheet-handle" />
+            <div className="assign-sheet-title">{editState.cat.category}</div>
+            <label className="assign-label" htmlFor="assign-input">Assigned amount</label>
+            <input
+              id="assign-input"
+              className="assign-input"
+              type="number"
+              inputMode="decimal"
+              value={editState.inputValue}
+              onChange={(e) =>
+                setEditState((prev) => prev ? { ...prev, inputValue: e.target.value } : null)
+              }
+              placeholder="0"
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+            />
+            {editState.saveError && (
+              <div className="assign-save-error">{editState.saveError}</div>
+            )}
+            <div className="assign-sheet-actions">
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={handleCancel}
+                disabled={editState.saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handleSave}
+                disabled={editState.saving}
+              >
+                {editState.saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/tests/unit/Plan.test.tsx
+++ b/tests/unit/Plan.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import type { Transaction, BudgetAssignment } from '../../src/types';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { Transaction, BudgetAssignment, CategoryWithActivity, GroupedBudget } from '../../src/types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -21,12 +21,16 @@ const mockFetchBudgetCategories = vi.fn().mockResolvedValue([]);
 const mockFetchMonthAssignments = vi.fn().mockResolvedValue([]);
 const mockFetchReadyToAssign = vi.fn().mockResolvedValue(0);
 const mockBuildGroupedBudget = vi.fn().mockReturnValue([]);
+const mockUpsertAssignment = vi.fn().mockResolvedValue(undefined);
+const mockAppendLogEntry = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../src/api/budget', () => ({
   fetchBudgetCategories: (...args: unknown[]) => mockFetchBudgetCategories(...args),
   fetchMonthAssignments: (...args: unknown[]) => mockFetchMonthAssignments(...args),
   fetchReadyToAssign: (...args: unknown[]) => mockFetchReadyToAssign(...args),
   buildGroupedBudget: (...args: unknown[]) => mockBuildGroupedBudget(...args),
+  upsertAssignment: (...args: unknown[]) => mockUpsertAssignment(...args),
+  appendLogEntry: (...args: unknown[]) => mockAppendLogEntry(...args),
 }));
 
 const mockFetchTransactions = vi.fn();
@@ -76,6 +80,33 @@ function makeAssignment(assigned: number): BudgetAssignment {
   return { month: '2026-04', category: 'Groceries', assigned, source: 'manual', _rowIndex: 509 };
 }
 
+function makeCat(overrides: Partial<CategoryWithActivity> = {}): CategoryWithActivity {
+  return {
+    category_group: 'Food',
+    category_subgroup: '',
+    category: 'Groceries',
+    category_type: 'fluid',
+    monthly_template_amount: 0,
+    sort_order: 1,
+    active: true,
+    _rowIndex: 7,
+    assigned: 400,
+    activity: 100,
+    available: 300,
+    ...overrides,
+  };
+}
+
+function makeGroupedBudget(cats: CategoryWithActivity[] = [makeCat()]): GroupedBudget[] {
+  return [{
+    groupName: 'Food',
+    subgroups: [{ subgroupName: '', categories: cats }],
+    totalAssigned: cats.reduce((s, c) => s + c.assigned, 0),
+    totalActivity: cats.reduce((s, c) => s + c.activity, 0),
+    totalAvailable: cats.reduce((s, c) => s + c.available, 0),
+  }];
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('Plan screen — Ready to Assign', () => {
@@ -86,6 +117,8 @@ describe('Plan screen — Ready to Assign', () => {
     mockFetchTransactions.mockResolvedValue([]);
     mockBuildGroupedBudget.mockReturnValue([]);
     mockComputeCategoryActivity.mockReturnValue({});
+    mockUpsertAssignment.mockResolvedValue(undefined);
+    mockAppendLogEntry.mockResolvedValue(undefined);
   });
 
   it('shows positive Ready to Assign from the sheet formula in green', async () => {
@@ -116,5 +149,146 @@ describe('Plan screen — Ready to Assign', () => {
     const valueEl = screen.getByText('-$300');
     expect(valueEl).toHaveClass('negative');
     expect(valueEl).not.toHaveClass('positive');
+  });
+});
+
+describe('Plan screen — assign money', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchBudgetCategories.mockResolvedValue([]);
+    mockFetchMonthAssignments.mockResolvedValue([makeAssignment(400)]);
+    mockFetchTransactions.mockResolvedValue([]);
+    mockFetchReadyToAssign.mockResolvedValue(500);
+    mockBuildGroupedBudget.mockReturnValue(makeGroupedBudget());
+    mockComputeCategoryActivity.mockReturnValue(new Map());
+    mockUpsertAssignment.mockResolvedValue(undefined);
+    mockAppendLogEntry.mockResolvedValue(undefined);
+  });
+
+  it('opens the assignment sheet when a category row is clicked', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('prefills the input with the current assigned amount', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(400);
+  });
+
+  it('shows empty input when assigned is zero', async () => {
+    mockBuildGroupedBudget.mockReturnValue(makeGroupedBudget([makeCat({ assigned: 0, available: 0 })]));
+
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(null);
+  });
+
+  it('cancel closes the assignment sheet without saving', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    expect(mockUpsertAssignment).not.toHaveBeenCalled();
+  });
+
+  it('clicking the overlay backdrop closes the sheet', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+
+    fireEvent.click(document.querySelector('.assign-overlay')!);
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+  });
+
+  it('save calls upsertAssignment with new amount and existing row', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockUpsertAssignment).toHaveBeenCalled());
+    expect(mockUpsertAssignment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      'Groceries',
+      500,
+      makeAssignment(400)
+    );
+  });
+
+  it('save calls appendLogEntry with the delta', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '600' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockAppendLogEntry).toHaveBeenCalled());
+    expect(mockAppendLogEntry).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      'Groceries',
+      200, // delta: 600 - 400
+      'manual'
+    );
+  });
+
+  it('empty input saves 0, not NaN', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockUpsertAssignment).toHaveBeenCalled());
+    const [, , , amount] = mockUpsertAssignment.mock.calls[0];
+    expect(amount).toBe(0);
+    expect(Number.isNaN(amount)).toBe(false);
+  });
+
+  it('closes the sheet after a successful save', async () => {
+    const { default: Plan } = await import('../../src/screens/Plan');
+    render(<Plan />);
+
+    const row = await screen.findByRole('button', { name: /Groceries/i });
+    fireEvent.click(row);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/unit/budget-fetch.test.ts
+++ b/tests/unit/budget-fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fetchBudgetCategories, fetchMonthAssignments, upsertAssignment, fetchReadyToAssign } from '../../src/api/budget';
+import { fetchBudgetCategories, fetchMonthAssignments, upsertAssignment, fetchReadyToAssign, appendLogEntry } from '../../src/api/budget';
 import type { SheetsClient } from '../../src/api/client';
 
 // ─── Mock helpers ─────────────────────────────────────────────────────────────
@@ -186,5 +186,49 @@ describe('upsertAssignment', () => {
       [['2025-04', 'Gas', 75, 'manual']]
     );
     expect(client.updateValues).not.toHaveBeenCalled();
+  });
+});
+
+// ─── appendLogEntry ───────────────────────────────────────────────────────────
+
+describe('appendLogEntry', () => {
+  it('appends a log row to Budget_Log with correct fields', async () => {
+    const client = mockClient([]);
+    await appendLogEntry(client, '2026-04', 'Groceries', 100, 'manual');
+    expect(client.appendValues).toHaveBeenCalledWith(
+      'Budget_Log!A2',
+      [[expect.any(String), '2026-04', 'Groceries', 100, 'manual', '']]
+    );
+  });
+
+  it('uses empty string as default note', async () => {
+    const client = mockClient([]);
+    await appendLogEntry(client, '2026-04', 'Groceries', 50, 'manual');
+    const [[, [row]]] = (client.appendValues as ReturnType<typeof vi.fn>).mock.calls;
+    expect(row[5]).toBe('');
+  });
+
+  it('includes the note when provided', async () => {
+    const client = mockClient([]);
+    await appendLogEntry(client, '2026-04', 'Gas', -50, 'move_from:Groceries', 'rebalance');
+    const [[, [row]]] = (client.appendValues as ReturnType<typeof vi.fn>).mock.calls;
+    expect(row[4]).toBe('move_from:Groceries');
+    expect(row[5]).toBe('rebalance');
+  });
+
+  it('records the timestamp as an ISO string', async () => {
+    const client = mockClient([]);
+    const before = new Date().toISOString();
+    await appendLogEntry(client, '2026-04', 'Groceries', 100, 'manual');
+    const after = new Date().toISOString();
+    const [[, [row]]] = (client.appendValues as ReturnType<typeof vi.fn>).mock.calls;
+    expect(row[0] >= before && row[0] <= after).toBe(true);
+  });
+
+  it('passes negative deltas for decreases', async () => {
+    const client = mockClient([]);
+    await appendLogEntry(client, '2026-04', 'Dining Out', -200, 'manual');
+    const [[, [row]]] = (client.appendValues as ReturnType<typeof vi.fn>).mock.calls;
+    expect(row[3]).toBe(-200);
   });
 });


### PR DESCRIPTION
Closes #4

## Summary
- Tapping a category row opens a bottom sheet with a number input pre-filled with the current assigned amount
- Save calls `upsertAssignment()` then `appendLogEntry()`, reloads the Plan screen
- Adds `Budget_Log` tab to `setup-sheet.ts` (coordinates with #42)

## Test plan
- [x] `npm test` unit tests pass
- [x] Run `npm run setup:dev` to provision Budget_Log tab
- [x] Tap a category on the Plan screen — bottom sheet opens with current amount
- [x] Change amount and Save — Plan screen refreshes with new value
- [x] Cancel — no change written
- [x] Empty input — saves as 0

Generated with [Claude Code](https://claude.ai/code)