### PR TITLE
Move Activity/Available calculations to spreadsheet formulas with rollover (#46)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -135,18 +135,25 @@ const TABS_IN_ORDER = [
   "Templates",
   "Reflect",
   "Budget_Log",
+  "Budget_Calcs",
   "Transactions (BTS)",
   "Balance History (BTS)",
   "YNAB_Plan_Import",
   "YNAB_Transactions_Import",
 ];
 
+const BUDGET_CALCS_COLUMNS = ["month", "category", "activity", "assigned", "available"];
+
+// How many months back/forward from today to generate Budget_Calcs rows.
+const CALCS_MONTHS_BACK = 36;
+const CALCS_MONTHS_FORWARD = 24;
+
 // Header background color (Google blue)
 const HEADER_BG_COLOR = { red: 0.29, green: 0.525, blue: 0.91 };
 const HEADER_FG_COLOR = { red: 1, green: 1, blue: 1 };
 
 // Sheet schema version — increment when structure changes
-const SHEET_VERSION = 4;
+const SHEET_VERSION = 5;
 
 // ─── Environment Loading ───────────────────────────────────────────────────────
 
@@ -983,6 +990,147 @@ async function writeBudgetDashboard(
   log("Budget dashboard: wrote rows 1–4 (ReadyToAssign, LastYnabSync, TotalAssignedThisMonth, TotalAvailable)");
 }
 
+// ─── Step: Write Budget_Calcs Formulas ────────────────────────────────────────
+//
+// Budget_Calcs holds one row per (month, category) pair.
+// Each row has SUMPRODUCT-based formulas for Activity and Assigned, and a
+// rollover-aware Available formula that chains to the previous month's row.
+// The tab is cleared and rewritten on every setup run so it stays in sync
+// with any category changes and the rolling month window.
+
+function generateMonthRange(monthsBack: number, monthsForward: number): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  const baseYear = now.getFullYear();
+  const baseMonth = now.getMonth(); // 0-indexed
+
+  for (let offset = -monthsBack; offset <= monthsForward; offset++) {
+    const d = new Date(baseYear, baseMonth + offset, 1);
+    months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+  }
+  return months;
+}
+
+async function writeBudgetCalcs(
+  sheets: sheets_v4.Sheets,
+  sheetId: string,
+  sheetMeta: sheets_v4.Schema$Sheet[],
+  activeCategories: FlatCategory[]
+): Promise<void> {
+  const meta = findSheet(sheetMeta, "Budget_Calcs");
+  if (!meta) {
+    log("Budget_Calcs: tab not found, skipping");
+    return;
+  }
+
+  // Always clear and rewrite so month window and categories stay current.
+  await sheets.spreadsheets.values.clear({
+    spreadsheetId: sheetId,
+    range: "Budget_Calcs",
+  });
+
+  const months = generateMonthRange(CALCS_MONTHS_BACK, CALCS_MONTHS_FORWARD);
+  const cats = activeCategories.filter((c) => c.active).sort((a, b) => a.sort_order - b.sort_order);
+  const N = cats.length; // rows per month block
+
+  if (N === 0) {
+    log("Budget_Calcs: no active categories, skipping formula rows");
+    return;
+  }
+
+  // Row 1 = headers; data starts at row 2.
+  const HEADER_ROW = 1;
+  const DATA_START = HEADER_ROW + 1;
+  const assignDataStart = BUDGET_ASSIGNMENTS_START_ROW + 1; // 509
+
+  // Build all formula rows. Row R for monthIdx m, catIdx c = DATA_START + m*N + c.
+  const rows: (string | number)[][] = [];
+  for (let m = 0; m < months.length; m++) {
+    for (let c = 0; c < N; c++) {
+      const R = DATA_START + m * N + c;
+      const month = months[m];
+      const catName = cats[c].category;
+
+      // Activity: outflows minus inflows for this category+month, excluding
+      // split child rows (parent_id non-empty) and transfer transactions.
+      const activityFormula =
+        `=SUMPRODUCT((Transactions!$K$2:$K$5000=B${R})*(TEXT(Transactions!$H$2:$H$5000,"yyyy-mm")=A${R})*(Transactions!$B$2:$B$5000="")*(Transactions!$T$2:$T$5000<>"transfer")*Transactions!$P$2:$P$5000)` +
+        `-SUMPRODUCT((Transactions!$K$2:$K$5000=B${R})*(TEXT(Transactions!$H$2:$H$5000,"yyyy-mm")=A${R})*(Transactions!$B$2:$B$5000="")*(Transactions!$T$2:$T$5000<>"transfer")*Transactions!$Q$2:$Q$5000)`;
+
+      // Assigned: sum of all assignment rows for this category+month.
+      const assignedFormula =
+        `=SUMPRODUCT((Budget!$A$${assignDataStart}:$A$5000=A${R})*(Budget!$B$${assignDataStart}:$B$5000=B${R})*Budget!$C$${assignDataStart}:$C$5000)`;
+
+      // Available: previous month's available + this month's assigned − activity.
+      // First month block has no prior row so rollover is 0.
+      const availableFormula = m === 0
+        ? `=D${R}-C${R}`
+        : `=E${R - N}+D${R}-C${R}`;
+
+      rows.push([month, catName, activityFormula, assignedFormula, availableFormula]);
+    }
+  }
+
+  // Write header row
+  await sheets.spreadsheets.values.update({
+    spreadsheetId: sheetId,
+    range: "Budget_Calcs!A1",
+    valueInputOption: "RAW",
+    requestBody: { values: [BUDGET_CALCS_COLUMNS] },
+  });
+
+  // Write formula rows in yearly chunks to stay well within API payload limits.
+  const CHUNK_MONTHS = 12;
+  const rowsPerChunk = CHUNK_MONTHS * N;
+  for (let start = 0; start < rows.length; start += rowsPerChunk) {
+    const chunk = rows.slice(start, start + rowsPerChunk);
+    const startRow = DATA_START + start;
+    await sheets.spreadsheets.values.update({
+      spreadsheetId: sheetId,
+      range: `Budget_Calcs!A${startRow}`,
+      valueInputOption: "USER_ENTERED",
+      requestBody: { values: chunk },
+    });
+  }
+
+  // Freeze the header row.
+  const tabSheetId = meta.properties?.sheetId!;
+  await sheets.spreadsheets.batchUpdate({
+    spreadsheetId: sheetId,
+    requestBody: {
+      requests: [
+        {
+          updateSheetProperties: {
+            properties: {
+              sheetId: tabSheetId,
+              gridProperties: { frozenRowCount: 1 },
+            },
+            fields: "gridProperties.frozenRowCount",
+          },
+        },
+        {
+          repeatCell: {
+            range: {
+              sheetId: tabSheetId,
+              startRowIndex: 0,
+              endRowIndex: 1,
+            },
+            cell: {
+              userEnteredFormat: {
+                backgroundColor: HEADER_BG_COLOR,
+                textFormat: { foregroundColor: HEADER_FG_COLOR, bold: true },
+              },
+            },
+            fields: "userEnteredFormat(backgroundColor,textFormat)",
+          },
+        },
+      ],
+    },
+  });
+
+  log(`Budget_Calcs: wrote ${rows.length} rows (${months.length} months × ${N} categories)`);
+}
+
 // ─── Step: Write Sheet Version ────────────────────────────────────────────────
 
 async function writeSheetVersion(
@@ -1075,7 +1223,10 @@ async function main(): Promise<void> {
   // 12. Write Budget dashboard header (rows 1–5) with named ranges
   await writeBudgetDashboard(sheets, sheetId, sheetMeta);
 
-  // 13. Write sheet version
+  // 13. Write Budget_Calcs formulas (activity + available with rollover, per category per month)
+  await writeBudgetCalcs(sheets, sheetId, sheetMeta, flatCategories);
+
+  // 14. Write sheet version
   await writeSheetVersion(sheets, sheetId);
 
   console.log(

--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -993,7 +993,7 @@ async function writeBudgetDashboard(
 // ─── Step: Write Budget_Calcs Formulas ────────────────────────────────────────
 //
 // Budget_Calcs holds one row per (month, category) pair.
-// Each row has SUMPRODUCT-based formulas for Activity and Assigned, and a
+// Each row has SUMIFS-based formulas for Activity and Assigned, and a
 // rollover-aware Available formula that chains to the previous month's row.
 // The tab is cleared and rewritten on every setup run so it stays in sync
 // with any category changes and the rolling month window.
@@ -1076,13 +1076,17 @@ async function writeBudgetCalcs(
 
       // Activity: outflows minus inflows for this category+month, excluding
       // split child rows (parent_id non-empty) and transfer transactions.
+      // SUMIFS with date range bounds is much faster than SUMPRODUCT+TEXT() array expansion.
+      const monthStart = `DATEVALUE(A${R}&"-01")`;
+      const monthEnd = `EDATE(${monthStart},1)`;
+      const txBase = `Transactions!$K$2:$K$5000,B${R},Transactions!$H$2:$H$5000,">="&${monthStart},Transactions!$H$2:$H$5000,"<"&${monthEnd},Transactions!$B$2:$B$5000,"",Transactions!$T$2:$T$5000,"<>transfer"`;
       const activityFormula =
-        `=SUMPRODUCT((Transactions!$K$2:$K$5000=B${R})*(TEXT(Transactions!$H$2:$H$5000,"yyyy-mm")=A${R})*(Transactions!$B$2:$B$5000="")*(Transactions!$T$2:$T$5000<>"transfer")*Transactions!$P$2:$P$5000)` +
-        `-SUMPRODUCT((Transactions!$K$2:$K$5000=B${R})*(TEXT(Transactions!$H$2:$H$5000,"yyyy-mm")=A${R})*(Transactions!$B$2:$B$5000="")*(Transactions!$T$2:$T$5000<>"transfer")*Transactions!$Q$2:$Q$5000)`;
+        `=SUMIFS(Transactions!$P$2:$P$5000,${txBase})` +
+        `-SUMIFS(Transactions!$Q$2:$Q$5000,${txBase})`;
 
       // Assigned: sum of all assignment rows for this category+month.
       const assignedFormula =
-        `=SUMPRODUCT((Budget!$A$${assignDataStart}:$A$5000=A${R})*(Budget!$B$${assignDataStart}:$B$5000=B${R})*Budget!$C$${assignDataStart}:$C$5000)`;
+        `=SUMIFS(Budget!$C$${assignDataStart}:$C$5000,Budget!$A$${assignDataStart}:$A$5000,A${R},Budget!$B$${assignDataStart}:$B$5000,B${R})`;
 
       // Available: previous month's available + this month's assigned − activity.
       // First month block has no prior row so rollover is 0.

--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -1023,12 +1023,6 @@ async function writeBudgetCalcs(
     return;
   }
 
-  // Always clear and rewrite so month window and categories stay current.
-  await sheets.spreadsheets.values.clear({
-    spreadsheetId: sheetId,
-    range: "Budget_Calcs",
-  });
-
   const months = generateMonthRange(CALCS_MONTHS_BACK, CALCS_MONTHS_FORWARD);
   const cats = activeCategories.filter((c) => c.active).sort((a, b) => a.sort_order - b.sort_order);
   const N = cats.length; // rows per month block
@@ -1041,6 +1035,35 @@ async function writeBudgetCalcs(
   // Row 1 = headers; data starts at row 2.
   const HEADER_ROW = 1;
   const DATA_START = HEADER_ROW + 1;
+
+  // Ensure the grid is large enough before writing. New tabs default to 1000
+  // rows which is often insufficient for months × categories.
+  const requiredRows = DATA_START + months.length * N;
+  const tabSheetId = meta.properties?.sheetId!;
+  const currentRowCount = meta.properties?.gridProperties?.rowCount ?? 0;
+  if (currentRowCount < requiredRows) {
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: sheetId,
+      requestBody: {
+        requests: [{
+          updateSheetProperties: {
+            properties: {
+              sheetId: tabSheetId,
+              gridProperties: { rowCount: requiredRows },
+            },
+            fields: "gridProperties.rowCount",
+          },
+        }],
+      },
+    });
+    log(`Budget_Calcs: expanded grid to ${requiredRows} rows`);
+  }
+
+  // Always clear and rewrite so month window and categories stay current.
+  await sheets.spreadsheets.values.clear({
+    spreadsheetId: sheetId,
+    range: "Budget_Calcs",
+  });
   const assignDataStart = BUDGET_ASSIGNMENTS_START_ROW + 1; // 509
 
   // Build all formula rows. Row R for monthIdx m, catIdx c = DATA_START + m*N + c.
@@ -1094,7 +1117,6 @@ async function writeBudgetCalcs(
   }
 
   // Freeze the header row.
-  const tabSheetId = meta.properties?.sheetId!;
   await sheets.spreadsheets.batchUpdate({
     spreadsheetId: sheetId,
     requestBody: {

--- a/src/api/budget.ts
+++ b/src/api/budget.ts
@@ -1,5 +1,5 @@
 import { SheetsClient } from './client';
-import { BudgetCategory, BudgetAssignment, CategoryType, CategoryWithActivity, GroupedBudget } from '../types';
+import { BudgetCategory, BudgetAssignment, CategoryType, CategoryWithActivity, GroupedBudget, CategoryCalcs } from '../types';
 
 // Column order must match scripts/setup-sheet.ts BUDGET_CATEGORY_COLUMNS exactly.
 const CATEGORY_COLS = [
@@ -127,24 +127,51 @@ export async function appendLogEntry(
   ]);
 }
 
+/**
+ * Fetch pre-calculated activity and available per category for the given month
+ * from the Budget_Calcs tab. Available already includes rollover from prior months.
+ * @param month — "YYYY-MM" format
+ */
+export async function fetchCategoryCalcs(
+  client: SheetsClient,
+  month: string
+): Promise<Map<string, CategoryCalcs>> {
+  const res = await client.getValues('Budget_Calcs!A:E');
+  const rows = res.values ?? [];
+  const map = new Map<string, CategoryCalcs>();
+  // Row 0 is headers; skip it
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if ((row[0] ?? '') !== month) continue;
+    const category = row[1] ?? '';
+    if (!category) continue;
+    map.set(category, {
+      activity: parseFloat(row[2]) || 0,
+      available: parseFloat(row[4]) || 0,
+    });
+  }
+  return map;
+}
+
 // ─── View builders ────────────────────────────────────────────────────────────
 
 /**
- * Merge categories, assignments, and activity into a grouped budget view.
+ * Merge categories, assignments, and pre-calculated calcs into a grouped budget view.
+ * Activity and available come from Budget_Calcs (sheet-computed, includes rollover).
  * This is the primary data structure consumed by the Plan screen.
  */
 export function buildGroupedBudget(
   categories: BudgetCategory[],
   assignments: BudgetAssignment[],
-  activityMap: Map<string, number>
+  calcMap: Map<string, CategoryCalcs>
 ): GroupedBudget[] {
   const assignMap = new Map(assignments.map((a) => [a.category, a.assigned]));
 
-  // Enrich categories with computed fields
+  // Enrich categories with sheet-computed fields
   const enriched: CategoryWithActivity[] = categories.map((cat) => {
     const assigned = assignMap.get(cat.category) ?? 0;
-    const activity = activityMap.get(cat.category) ?? 0;
-    return { ...cat, assigned, activity, available: assigned - activity };
+    const calcs = calcMap.get(cat.category) ?? { activity: 0, available: 0 };
+    return { ...cat, assigned, activity: calcs.activity, available: calcs.available };
   });
 
   // Group → subgroup → categories

--- a/src/screens/Plan.tsx
+++ b/src/screens/Plan.tsx
@@ -5,12 +5,12 @@ import { SheetsClient } from '../api/client';
 import {
   fetchBudgetCategories,
   fetchMonthAssignments,
+  fetchCategoryCalcs,
   buildGroupedBudget,
   fetchReadyToAssign,
   upsertAssignment,
   appendLogEntry,
 } from '../api/budget';
-import { fetchTransactions, computeCategoryActivity } from '../api/transactions';
 import { GroupedBudget, BudgetAssignment, CategoryWithActivity } from '../types';
 
 const SHEET_ID = import.meta.env.VITE_GOOGLE_SHEET_ID as string;
@@ -54,14 +54,13 @@ export default function Plan() {
     setError(null);
 
     try {
-      const [cats, rawAssignments, txns] = await Promise.all([
+      const [cats, rawAssignments, calcs] = await Promise.all([
         fetchBudgetCategories(client),
         fetchMonthAssignments(client, month),
-        fetchTransactions(client, { month }),
+        fetchCategoryCalcs(client, month),
       ]);
-      const activityMap = computeCategoryActivity(txns);
       setAssignments(rawAssignments);
-      setGroups(buildGroupedBudget(cats, rawAssignments, activityMap));
+      setGroups(buildGroupedBudget(cats, rawAssignments, calcs));
       setReadyToAssign(await fetchReadyToAssign(client));
     } catch (e) {
       setError((e as Error).message);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,11 +72,17 @@ export interface Template {
 
 // ─── Derived / Computed ────────────────────────────────────────────────────────
 
+/** Pre-calculated activity and available for one category in one month, from Budget_Calcs tab. */
+export interface CategoryCalcs {
+  activity: number; // outflow − inflow for the month
+  available: number; // includes rollover from prior months
+}
+
 /** A budget category enriched with computed month values. */
 export interface CategoryWithActivity extends BudgetCategory {
   assigned: number;
   activity: number; // outflow − inflow for the month
-  available: number; // assigned − activity
+  available: number; // available for the month (includes rollover from prior months)
 }
 
 /** Budget view for a single month, grouped for rendering. */

--- a/tests/integration/budget-calcs.test.ts
+++ b/tests/integration/budget-calcs.test.ts
@@ -10,7 +10,14 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { google } from 'googleapis';
-import * as fs from 'fs';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.development' });
+
+// GOOGLE_SERVICE_ACCOUNT_KEY_PATH is the local dev alias for the key file.
+if (process.env.GOOGLE_SERVICE_ACCOUNT_KEY_PATH && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_PATH;
+}
 
 // Skip all tests if credentials are not available
 const hasCredentials =

--- a/tests/integration/budget-calcs.test.ts
+++ b/tests/integration/budget-calcs.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration tests for Budget_Calcs tab rollover behavior.
+ * @integration
+ *
+ * These tests run against the dev Google Sheet and require:
+ *   GOOGLE_APPLICATION_CREDENTIALS pointing to a service account key
+ *   GOOGLE_SHEET_ID set to the dev sheet
+ *
+ * Run with: npm run test:integration
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { google } from 'googleapis';
+import * as fs from 'fs';
+
+// Skip all tests if credentials are not available
+const hasCredentials =
+  !!process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+  !!process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+
+const describeIf = hasCredentials ? describe : describe.skip;
+
+describeIf('Budget_Calcs rollover @integration', () => {
+  let sheets: ReturnType<typeof google.sheets>;
+  let sheetId: string;
+
+  beforeAll(async () => {
+    sheetId = process.env.GOOGLE_SHEET_ID ?? '';
+    if (!sheetId) throw new Error('GOOGLE_SHEET_ID is not set');
+
+    const inlineKey = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+    const auth = new google.auth.GoogleAuth({
+      ...(inlineKey
+        ? { credentials: JSON.parse(inlineKey) }
+        : { keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS }),
+      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+    });
+    sheets = google.sheets({ version: 'v4', auth });
+  });
+
+  it('Budget_Calcs tab exists with headers', async () => {
+    const res = await sheets.spreadsheets.values.get({
+      spreadsheetId: sheetId,
+      range: 'Budget_Calcs!A1:E1',
+    });
+    const headers = res.data.values?.[0] ?? [];
+    expect(headers).toEqual(['month', 'category', 'activity', 'assigned', 'available']);
+  });
+
+  it('April available rolls over into May for a zero-spend category', async () => {
+    // Find a category that has $0 activity in both April and May.
+    // Its May Available should equal April Available + May Assigned.
+    const res = await sheets.spreadsheets.values.get({
+      spreadsheetId: sheetId,
+      range: 'Budget_Calcs!A:E',
+    });
+    const rows = res.data.values ?? [];
+
+    const forMonth = (month: string) => {
+      const map = new Map<string, { activity: number; available: number }>();
+      for (let i = 1; i < rows.length; i++) {
+        const row = rows[i];
+        if ((row[0] ?? '') !== month) continue;
+        const cat = row[1] ?? '';
+        if (!cat) continue;
+        map.set(cat, {
+          activity: parseFloat(row[2]) || 0,
+          available: parseFloat(row[4]) || 0,
+        });
+      }
+      return map;
+    };
+
+    const aprCalcs = forMonth('2026-04');
+    const mayCalcs = forMonth('2026-05');
+
+    expect(aprCalcs.size).toBeGreaterThan(0);
+    expect(mayCalcs.size).toBeGreaterThan(0);
+
+    // Find a category present in both months
+    const shared = [...aprCalcs.keys()].filter((k) => mayCalcs.has(k));
+    expect(shared.length).toBeGreaterThan(0);
+
+    // For each shared category: May available must equal April available +
+    // May assigned − May activity. We verify this by checking the formula
+    // result is internally consistent (the sheet evaluated it).
+    const aprAssignedRes = await sheets.spreadsheets.values.get({
+      spreadsheetId: sheetId,
+      range: 'Budget_Calcs!A:D',
+    });
+    const assignedRows = aprAssignedRes.data.values ?? [];
+    const mayAssigned = new Map<string, number>();
+    for (let i = 1; i < assignedRows.length; i++) {
+      const row = assignedRows[i];
+      if ((row[0] ?? '') !== '2026-05') continue;
+      mayAssigned.set(row[1] ?? '', parseFloat(row[3]) || 0);
+    }
+
+    for (const cat of shared) {
+      const aprAvail = aprCalcs.get(cat)!.available;
+      const mayAct = mayCalcs.get(cat)!.activity;
+      const mayAsgn = mayAssigned.get(cat) ?? 0;
+      const expected = aprAvail + mayAsgn - mayAct;
+      const actual = mayCalcs.get(cat)!.available;
+      expect(actual).toBeCloseTo(expected, 2);
+    }
+  });
+});

--- a/tests/integration/budget-calcs.test.ts
+++ b/tests/integration/budget-calcs.test.ts
@@ -19,6 +19,8 @@ if (process.env.GOOGLE_SERVICE_ACCOUNT_KEY_PATH && !process.env.GOOGLE_APPLICATI
   process.env.GOOGLE_APPLICATION_CREDENTIALS = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_PATH;
 }
 
+const TIMEOUT_MS = 30_000;
+
 // Skip all tests if credentials are not available
 const hasCredentials =
   !!process.env.GOOGLE_APPLICATION_CREDENTIALS ||
@@ -42,7 +44,7 @@ describeIf('Budget_Calcs rollover @integration', () => {
       scopes: ['https://www.googleapis.com/auth/spreadsheets'],
     });
     sheets = google.sheets({ version: 'v4', auth });
-  });
+  }, TIMEOUT_MS);
 
   it('Budget_Calcs tab exists with headers', async () => {
     const res = await sheets.spreadsheets.values.get({
@@ -51,11 +53,10 @@ describeIf('Budget_Calcs rollover @integration', () => {
     });
     const headers = res.data.values?.[0] ?? [];
     expect(headers).toEqual(['month', 'category', 'activity', 'assigned', 'available']);
-  });
+  }, TIMEOUT_MS);
 
   it('April available rolls over into May for a zero-spend category', async () => {
-    // Find a category that has $0 activity in both April and May.
-    // Its May Available should equal April Available + May Assigned.
+    // Read the full Budget_Calcs tab in one call
     const res = await sheets.spreadsheets.values.get({
       spreadsheetId: sheetId,
       range: 'Budget_Calcs!A:E',
@@ -63,7 +64,7 @@ describeIf('Budget_Calcs rollover @integration', () => {
     const rows = res.data.values ?? [];
 
     const forMonth = (month: string) => {
-      const map = new Map<string, { activity: number; available: number }>();
+      const map = new Map<string, { activity: number; assigned: number; available: number }>();
       for (let i = 1; i < rows.length; i++) {
         const row = rows[i];
         if ((row[0] ?? '') !== month) continue;
@@ -71,6 +72,7 @@ describeIf('Budget_Calcs rollover @integration', () => {
         if (!cat) continue;
         map.set(cat, {
           activity: parseFloat(row[2]) || 0,
+          assigned: parseFloat(row[3]) || 0,
           available: parseFloat(row[4]) || 0,
         });
       }
@@ -83,32 +85,15 @@ describeIf('Budget_Calcs rollover @integration', () => {
     expect(aprCalcs.size).toBeGreaterThan(0);
     expect(mayCalcs.size).toBeGreaterThan(0);
 
-    // Find a category present in both months
     const shared = [...aprCalcs.keys()].filter((k) => mayCalcs.has(k));
     expect(shared.length).toBeGreaterThan(0);
 
-    // For each shared category: May available must equal April available +
-    // May assigned − May activity. We verify this by checking the formula
-    // result is internally consistent (the sheet evaluated it).
-    const aprAssignedRes = await sheets.spreadsheets.values.get({
-      spreadsheetId: sheetId,
-      range: 'Budget_Calcs!A:D',
-    });
-    const assignedRows = aprAssignedRes.data.values ?? [];
-    const mayAssigned = new Map<string, number>();
-    for (let i = 1; i < assignedRows.length; i++) {
-      const row = assignedRows[i];
-      if ((row[0] ?? '') !== '2026-05') continue;
-      mayAssigned.set(row[1] ?? '', parseFloat(row[3]) || 0);
-    }
-
+    // For each shared category: May available = April available + May assigned − May activity
     for (const cat of shared) {
       const aprAvail = aprCalcs.get(cat)!.available;
-      const mayAct = mayCalcs.get(cat)!.activity;
-      const mayAsgn = mayAssigned.get(cat) ?? 0;
-      const expected = aprAvail + mayAsgn - mayAct;
-      const actual = mayCalcs.get(cat)!.available;
-      expect(actual).toBeCloseTo(expected, 2);
+      const may = mayCalcs.get(cat)!;
+      const expected = aprAvail + may.assigned - may.activity;
+      expect(may.available).toBeCloseTo(expected, 2);
     }
-  });
+  }, TIMEOUT_MS);
 });

--- a/tests/unit/Plan.test.tsx
+++ b/tests/unit/Plan.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import type { Transaction, BudgetAssignment, CategoryWithActivity, GroupedBudget } from '../../src/types';
+import type { BudgetAssignment, CategoryWithActivity, GroupedBudget } from '../../src/types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -19,6 +19,7 @@ vi.mock('../../src/api/client', () => ({
 
 const mockFetchBudgetCategories = vi.fn().mockResolvedValue([]);
 const mockFetchMonthAssignments = vi.fn().mockResolvedValue([]);
+const mockFetchCategoryCalcs = vi.fn().mockResolvedValue(new Map());
 const mockFetchReadyToAssign = vi.fn().mockResolvedValue(0);
 const mockBuildGroupedBudget = vi.fn().mockReturnValue([]);
 const mockUpsertAssignment = vi.fn().mockResolvedValue(undefined);
@@ -27,54 +28,14 @@ const mockAppendLogEntry = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../src/api/budget', () => ({
   fetchBudgetCategories: (...args: unknown[]) => mockFetchBudgetCategories(...args),
   fetchMonthAssignments: (...args: unknown[]) => mockFetchMonthAssignments(...args),
+  fetchCategoryCalcs: (...args: unknown[]) => mockFetchCategoryCalcs(...args),
   fetchReadyToAssign: (...args: unknown[]) => mockFetchReadyToAssign(...args),
   buildGroupedBudget: (...args: unknown[]) => mockBuildGroupedBudget(...args),
   upsertAssignment: (...args: unknown[]) => mockUpsertAssignment(...args),
   appendLogEntry: (...args: unknown[]) => mockAppendLogEntry(...args),
 }));
 
-const mockFetchTransactions = vi.fn();
-const mockComputeCategoryActivity = vi.fn().mockReturnValue({});
-
-vi.mock('../../src/api/transactions', () => ({
-  fetchTransactions: (...args: unknown[]) => mockFetchTransactions(...args),
-  computeCategoryActivity: (...args: unknown[]) => mockComputeCategoryActivity(...args),
-}));
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function makeTransaction(overrides: Partial<Transaction>): Transaction {
-  return {
-    transaction_id: 't1',
-    parent_id: '',
-    split_group_id: '',
-    source: 'manual',
-    external_id: '',
-    imported_at: '',
-    status: 'cleared',
-    date: '2026-04-15',
-    payee: 'Test',
-    description: '',
-    category: '',
-    suggested_category: '',
-    category_subgroup: '',
-    category_group: '',
-    category_type: '',
-    outflow: 0,
-    inflow: 0,
-    account: '',
-    memo: '',
-    transaction_type: 'credit',
-    transfer_pair_id: '',
-    flag: '',
-    needs_reimbursement: false,
-    reimbursement_amount: 0,
-    matched_id: '',
-    reviewed: false,
-    _rowIndex: 2,
-    ...overrides,
-  };
-}
 
 function makeAssignment(assigned: number): BudgetAssignment {
   return { month: '2026-04', category: 'Groceries', assigned, source: 'manual', _rowIndex: 509 };
@@ -114,9 +75,8 @@ describe('Plan screen — Ready to Assign', () => {
     vi.clearAllMocks();
     mockFetchBudgetCategories.mockResolvedValue([]);
     mockFetchMonthAssignments.mockResolvedValue([]);
-    mockFetchTransactions.mockResolvedValue([]);
+    mockFetchCategoryCalcs.mockResolvedValue(new Map());
     mockBuildGroupedBudget.mockReturnValue([]);
-    mockComputeCategoryActivity.mockReturnValue({});
     mockUpsertAssignment.mockResolvedValue(undefined);
     mockAppendLogEntry.mockResolvedValue(undefined);
   });
@@ -157,10 +117,9 @@ describe('Plan screen — assign money', () => {
     vi.clearAllMocks();
     mockFetchBudgetCategories.mockResolvedValue([]);
     mockFetchMonthAssignments.mockResolvedValue([makeAssignment(400)]);
-    mockFetchTransactions.mockResolvedValue([]);
+    mockFetchCategoryCalcs.mockResolvedValue(new Map());
     mockFetchReadyToAssign.mockResolvedValue(500);
     mockBuildGroupedBudget.mockReturnValue(makeGroupedBudget());
-    mockComputeCategoryActivity.mockReturnValue(new Map());
     mockUpsertAssignment.mockResolvedValue(undefined);
     mockAppendLogEntry.mockResolvedValue(undefined);
   });

--- a/tests/unit/budget-fetch.test.ts
+++ b/tests/unit/budget-fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fetchBudgetCategories, fetchMonthAssignments, upsertAssignment, fetchReadyToAssign, appendLogEntry } from '../../src/api/budget';
+import { fetchBudgetCategories, fetchMonthAssignments, upsertAssignment, fetchReadyToAssign, appendLogEntry, fetchCategoryCalcs } from '../../src/api/budget';
 import type { SheetsClient } from '../../src/api/client';
 
 // ─── Mock helpers ─────────────────────────────────────────────────────────────
@@ -230,5 +230,85 @@ describe('appendLogEntry', () => {
     await appendLogEntry(client, '2026-04', 'Dining Out', -200, 'manual');
     const [[, [row]]] = (client.appendValues as ReturnType<typeof vi.fn>).mock.calls;
     expect(row[3]).toBe(-200);
+  });
+});
+
+// ─── fetchCategoryCalcs ───────────────────────────────────────────────────────
+
+// Budget_Calcs columns: month, category, activity, assigned, available
+function calcsRow(month: string, category: string, activity: string, assigned: string, available: string): string[] {
+  return [month, category, activity, assigned, available];
+}
+
+describe('fetchCategoryCalcs', () => {
+  it('returns empty map when sheet has no data rows', async () => {
+    const client = mockClient([]);
+    expect((await fetchCategoryCalcs(client, '2025-04')).size).toBe(0);
+  });
+
+  it('skips the header row and filters by month', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'], // header
+      calcsRow('2025-03', 'Groceries', '300', '400', '100'),
+      calcsRow('2025-04', 'Groceries', '320', '500', '180'),
+      calcsRow('2025-04', 'Dining Out', '150', '200', '50'),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    expect(result.size).toBe(2);
+    expect(result.has('Groceries')).toBe(true);
+    expect(result.has('Dining Out')).toBe(true);
+    expect(result.has('Groceries')).toBe(true);
+    const groceries = result.get('Groceries')!;
+    expect(groceries.activity).toBe(320);
+    expect(groceries.available).toBe(180);
+  });
+
+  it('parses activity and available as floats', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'],
+      calcsRow('2025-04', 'Gas', '45.75', '100', '54.25'),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    const gas = result.get('Gas')!;
+    expect(gas.activity).toBe(45.75);
+    expect(gas.available).toBe(54.25);
+  });
+
+  it('defaults activity and available to 0 when values are empty', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'],
+      calcsRow('2025-04', 'Haircuts', '', '', ''),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    const haircuts = result.get('Haircuts')!;
+    expect(haircuts.activity).toBe(0);
+    expect(haircuts.available).toBe(0);
+  });
+
+  it('handles negative available (overspent with rollover)', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'],
+      calcsRow('2025-04', 'Dining Out', '250', '100', '-150'),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    expect(result.get('Dining Out')!.available).toBe(-150);
+  });
+
+  it('returns empty map when no rows match the month', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'],
+      calcsRow('2025-03', 'Groceries', '300', '400', '100'),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    expect(result.size).toBe(0);
+  });
+
+  it('skips rows with an empty category', async () => {
+    const client = mockClient([
+      ['month', 'category', 'activity', 'assigned', 'available'],
+      calcsRow('2025-04', '', '100', '200', '100'),
+    ]);
+    const result = await fetchCategoryCalcs(client, '2025-04');
+    expect(result.size).toBe(0);
   });
 });

--- a/tests/unit/budget.test.ts
+++ b/tests/unit/budget.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildGroupedBudget } from '../../src/api/budget';
-import { BudgetCategory, BudgetAssignment } from '../../src/types/index';
+import { BudgetCategory, BudgetAssignment, CategoryCalcs } from '../../src/types/index';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -19,7 +19,11 @@ function makeCategory(overrides: Partial<BudgetCategory> = {}): BudgetCategory {
 }
 
 function makeAssignment(category: string, assigned: number, month = '2025-04'): BudgetAssignment {
-  return { month, category, assigned, _rowIndex: 502 };
+  return { month, category, assigned, source: 'manual', _rowIndex: 502 };
+}
+
+function makeCalcs(activity: number, available: number): CategoryCalcs {
+  return { activity, available };
 }
 
 // ─── buildGroupedBudget ───────────────────────────────────────────────────────
@@ -36,20 +40,20 @@ describe('buildGroupedBudget', () => {
     expect(result.map((g) => g.groupName)).toContain('Transportation');
   });
 
-  it('computes available = assigned − activity', () => {
+  it('uses pre-calculated activity and available from calcMap', () => {
     const categories = [makeCategory({ category: 'Groceries' })];
     const assignments = [makeAssignment('Groceries', 500)];
-    const activity = new Map([['Groceries', 320]]);
+    const calcMap = new Map([['Groceries', makeCalcs(320, 230)]]);
 
-    const result = buildGroupedBudget(categories, assignments, activity);
+    const result = buildGroupedBudget(categories, assignments, calcMap);
     const groceries = result[0].subgroups[0].categories[0];
 
     expect(groceries.assigned).toBe(500);
     expect(groceries.activity).toBe(320);
-    expect(groceries.available).toBe(180);
+    expect(groceries.available).toBe(230); // pre-calculated, includes rollover
   });
 
-  it('defaults assigned and activity to 0 when not provided', () => {
+  it('defaults activity and available to 0 when category not in calcMap', () => {
     const categories = [makeCategory({ category: 'Groceries' })];
     const result = buildGroupedBudget(categories, [], new Map());
     const cat = result[0].subgroups[0].categories[0];
@@ -65,9 +69,12 @@ describe('buildGroupedBudget', () => {
       makeCategory({ category: 'Dining Out', sort_order: 2 }),
     ];
     const assignments = [makeAssignment('Groceries', 500), makeAssignment('Dining Out', 200)];
-    const activity = new Map([['Groceries', 400], ['Dining Out', 150]]);
+    const calcMap = new Map([
+      ['Groceries', makeCalcs(400, 100)],
+      ['Dining Out', makeCalcs(150, 50)],
+    ]);
 
-    const [group] = buildGroupedBudget(categories, assignments, activity);
+    const [group] = buildGroupedBudget(categories, assignments, calcMap);
 
     expect(group.totalAssigned).toBe(700);
     expect(group.totalActivity).toBe(550);
@@ -98,15 +105,27 @@ describe('buildGroupedBudget', () => {
     expect(subgroupNames).toContain('Amara Activities');
   });
 
-  it('handles overspent categories (available goes negative)', () => {
+  it('handles overspent categories (available goes negative from calcMap)', () => {
     const categories = [makeCategory({ category: 'Dining Out' })];
     const assignments = [makeAssignment('Dining Out', 100)];
-    const activity = new Map([['Dining Out', 175]]);
+    const calcMap = new Map([['Dining Out', makeCalcs(175, -75)]]);
 
-    const result = buildGroupedBudget(categories, assignments, activity);
+    const result = buildGroupedBudget(categories, assignments, calcMap);
     const cat = result[0].subgroups[0].categories[0];
 
     expect(cat.available).toBe(-75);
     expect(result[0].totalAvailable).toBe(-75);
+  });
+
+  it('available reflects rollover from calcMap even if assigned is 0', () => {
+    // Simulates a category that had $50 left last month but nothing assigned this month
+    const categories = [makeCategory({ category: 'Haircuts' })];
+    const calcMap = new Map([['Haircuts', makeCalcs(0, 50)]]);
+
+    const result = buildGroupedBudget(categories, [], calcMap);
+    const cat = result[0].subgroups[0].categories[0];
+
+    expect(cat.assigned).toBe(0);
+    expect(cat.available).toBe(50); // rollover from prior month
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     environment: 'node',
     environmentMatchGlobs: [['tests/unit/**/*.test.tsx', 'jsdom']],
     setupFiles: ['./tests/setup.ts'],
-    include: ['tests/unit/**/*.test.{ts,tsx}'],
+    include: ['tests/**/*.test.{ts,tsx}'],
     // Emit JUnit XML so the GitHub Actions Test Reporter can annotate PRs.
     reporters: ['verbose', 'junit'],
     outputFile: { junit: 'test-results/junit.xml' },


### PR DESCRIPTION
- Add Budget_Calcs tab to setup-sheet.ts: one row per (month, category) with
  SUMPRODUCT-based Activity formula (excludes transfers + split children),
  SUMPRODUCT-based Assigned formula, and chain-referenced Available formula
  that rolls over prior month's balance automatically. Month window covers
  36 months back through 24 months forward from setup date.
- Add fetchCategoryCalcs() to budget.ts: reads pre-calculated activity and
  available from Budget_Calcs tab for a given month, returns Map keyed by
  category name.
- Update buildGroupedBudget() to accept calcMap (CategoryCalcs) instead of
  activityMap; activity and available are now sheet-computed values that
  include rollover, not client-side calculations.
- Update Plan.tsx: replace fetchTransactions + computeCategoryActivity with
  fetchCategoryCalcs — removes the transaction fetch from the Plan load path.
- Add CategoryCalcs type to types/index.ts.
- Update all affected unit tests; add integration test for rollover behavior.
- Bump SHEET_VERSION to 5.

https://claude.ai/code/session_01VxfUjZN3Rd4QZ6uvEyZV5J
Closes #46 