### PR TITLE
fix: prevent date-serial corruption in Budget assignments (#52)

### DIFF
--- a/scripts/setup-sheet.ts
+++ b/scripts/setup-sheet.ts
@@ -1185,6 +1185,85 @@ async function writeSheetVersion(
   log(`Sheet version: wrote SHEET_VERSION=${SHEET_VERSION} to Reflect!A1`);
 }
 
+// ─── Step: Clean Up Orphaned Assignment Rows ──────────────────────────────────
+
+const YYYYMM_RE = /^\d{4}-\d{2}$/;
+
+/**
+ * Remove any Budget assignment rows where the month cell is not in YYYY-MM
+ * format. This cleans up rows written before the USER_ENTERED → RAW fix, where
+ * Google Sheets silently converted "2026-05" to a date serial (e.g. 46143).
+ * Deletion is done via batchUpdate deleteRange requests, which physically
+ * removes the rows and shifts remaining data up.
+ */
+async function cleanOrphanedAssignmentRows(
+  sheets: sheets_v4.Sheets,
+  sheetId: string,
+  sheetMeta: sheets_v4.Schema$Sheet[]
+): Promise<void> {
+  const dataStart = BUDGET_ASSIGNMENTS_START_ROW + 1; // 509
+
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: sheetId,
+    range: `Budget!A${dataStart}:A`,
+  });
+
+  const rows = res.data.values ?? [];
+  if (rows.length === 0) {
+    log("Cleanup: no assignment data rows found, skipping");
+    return;
+  }
+
+  // Collect 0-based sheet row indices of orphaned rows (descending so we can
+  // delete bottom-up without shifting indices of earlier rows).
+  const orphanedIndices: number[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const cell = (rows[i]?.[0] ?? "").toString().trim();
+    if (cell !== "" && !YYYYMM_RE.test(cell)) {
+      orphanedIndices.push(dataStart - 1 + i); // convert to 0-based sheet row index
+    }
+  }
+
+  if (orphanedIndices.length === 0) {
+    log("Cleanup: no orphaned assignment rows found");
+    return;
+  }
+
+  log(`Cleanup: found ${orphanedIndices.length} orphaned assignment row(s) with invalid month values`);
+
+  const budgetMeta = findSheet(sheetMeta, "Budget");
+  if (!budgetMeta) {
+    log("Cleanup: Budget sheet metadata not found, skipping deletion");
+    return;
+  }
+  const tabSheetId = budgetMeta.properties?.sheetId!;
+
+  // Delete in descending order so row indices stay valid as we remove rows.
+  orphanedIndices.sort((a, b) => b - a);
+
+  // Batch into groups of 100 to stay within batchUpdate request limits.
+  const BATCH = 100;
+  for (let start = 0; start < orphanedIndices.length; start += BATCH) {
+    const chunk = orphanedIndices.slice(start, start + BATCH);
+    const requests = chunk.map((rowIdx) => ({
+      deleteRange: {
+        range: {
+          sheetId: tabSheetId,
+          startRowIndex: rowIdx,
+          endRowIndex: rowIdx + 1,
+        },
+        shiftDimension: "ROWS",
+      },
+    }));
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: sheetId,
+      requestBody: { requests },
+    });
+  }
+
+  log(`Cleanup: deleted ${orphanedIndices.length} orphaned assignment row(s)`);
+}
+
 // ─── Logging & Error Helpers ──────────────────────────────────────────────────
 
 function log(msg: string): void {
@@ -1254,6 +1333,9 @@ async function main(): Promise<void> {
 
   // 14. Write sheet version
   await writeSheetVersion(sheets, sheetId);
+
+  // 15. Clean up orphaned assignment rows (month stored as date serial instead of YYYY-MM text)
+  await cleanOrphanedAssignmentRows(sheets, sheetId, sheetMeta);
 
   console.log(
     "\n── Setup complete ───────────────────────────────────────────\n"

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -55,15 +55,18 @@ export class SheetsClient {
   /** PUT — overwrites the given range. */
   async updateValues(range: string, values: unknown[][]): Promise<void> {
     await this.request(
-      `/values/${enc(range)}?valueInputOption=USER_ENTERED`,
+      `/values/${enc(range)}?valueInputOption=RAW`,
       { method: 'PUT', body: JSON.stringify({ range, values }) }
     );
   }
 
-  /** POST — appends rows below the last non-empty row in the range. */
+  /** POST — appends rows below the last non-empty row in the range.
+   * Uses OVERWRITE (not INSERT_ROWS) to avoid triggering formula-range
+   * adjustments in dependent sheets (Budget_Calcs SUMIFS) which cause a
+   * brief recalculation gap where reads return stale zero values. */
   async appendValues(range: string, values: unknown[][]): Promise<void> {
     await this.request(
-      `/values/${enc(range)}:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS`,
+      `/values/${enc(range)}:append?valueInputOption=RAW&insertDataOption=OVERWRITE`,
       { method: 'POST', body: JSON.stringify({ range, values }) }
     );
   }
@@ -72,7 +75,7 @@ export class SheetsClient {
   async batchUpdateValues(data: { range: string; values: unknown[][] }[]): Promise<void> {
     await this.request('/values:batchUpdate', {
       method: 'POST',
-      body: JSON.stringify({ valueInputOption: 'USER_ENTERED', data }),
+      body: JSON.stringify({ valueInputOption: 'RAW', data }),
     });
   }
 

--- a/src/screens/Plan.tsx
+++ b/src/screens/Plan.tsx
@@ -119,6 +119,9 @@ export default function Plan() {
     try {
       const client = new SheetsClient(SHEET_ID, token);
       await applyTemplate(client, month, categories, assignments);
+      // Brief pause: lets Google Sheets finish recalculating SUMIFS formulas
+      // in Budget_Calcs before we read them back.
+      await new Promise((r) => setTimeout(r, 800));
       await load();
     } catch (e) {
       setError((e as Error).message);


### PR DESCRIPTION
## Summary

- Switch all Sheets API write operations to `valueInputOption=RAW` so month strings (`"2026-05"`) are never converted to date serials (`46143`)
- Switch `appendValues` to `insertDataOption=OVERWRITE` to avoid triggering formula-range recalculation gaps in Budget_Calcs
- Add 800ms delay in `handleApplyTemplate` before re-reading Budget_Calcs (SUMIFS need time to recalculate)
- Add `cleanOrphanedAssignmentRows` step in `setup-sheet.ts` that deletes assignment rows with non-`YYYY-MM` month values — runs as step 15 on both `setup:dev` and `setup:prod`

Closes #52

## Test plan

- [ ] CI passes (`npm test` + `setup:dev` + integration tests)
- [ ] After merge, `setup:prod` runs and logs "Cleanup: deleted 128 orphaned assignment row(s)"
- [ ] Apply Template on prod creates valid assignments; Move Money shows populated source picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)