### PR TITLE
feat(#10): triage mode, desktop top nav, TransactionType modernisation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback, useEffect } from 'react';
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './hooks/useAuth';
 import { useUnreviewedCount } from './hooks/useUnreviewedCount';
@@ -8,21 +9,26 @@ import OfflineBanner from './components/OfflineBanner';
 import Plan from './screens/Plan';
 import Accounts from './screens/Accounts';
 import Reflect from './screens/Reflect';
+import Triage from './screens/Triage';
 
-function AppBadge() {
+function AppBadge({ onCount }: { onCount: (n: number | null) => void }) {
   const count = useUnreviewedCount();
   useAppBadge(count);
+  useEffect(() => { onCount(count); }, [count, onCount]);
   return null;
 }
 
 export default function App() {
   const { isAuthenticated } = useAuth();
+  const [unreviewedCount, setUnreviewedCount] = useState<number | null>(null);
+  const handleCount = useCallback((n: number | null) => setUnreviewedCount(n), []);
 
   return (
     <HashRouter>
       <div className="app">
-        {isAuthenticated && <AppBadge />}
+        {isAuthenticated && <AppBadge onCount={handleCount} />}
         <OfflineBanner />
+        {isAuthenticated && <NavBar unreviewedCount={unreviewedCount} />}
         <main className="main-content">
           <Routes>
             <Route path="/" element={<Navigate to="/plan" replace />} />
@@ -38,7 +44,7 @@ export default function App() {
               path="/accounts"
               element={
                 <AuthGate>
-                  <Accounts />
+                  <Accounts unreviewedCount={unreviewedCount} />
                 </AuthGate>
               }
             />
@@ -50,9 +56,16 @@ export default function App() {
                 </AuthGate>
               }
             />
+            <Route
+              path="/triage"
+              element={
+                <AuthGate>
+                  <Triage />
+                </AuthGate>
+              }
+            />
           </Routes>
         </main>
-        {isAuthenticated && <NavBar />}
       </div>
     </HashRouter>
   );

--- a/src/api/transactions.ts
+++ b/src/api/transactions.ts
@@ -153,15 +153,59 @@ export async function updateTransactionFields(
 }
 
 /**
+ * Derive the semantic transaction type from a transaction's fields.
+ * Handles both new-style values ('income'|'transfer'|'regular') and legacy
+ * values ('debit'|'credit'|'transfer') that may exist in older sheet data.
+ */
+export function classifyTransactionType(tx: Transaction): TransactionType | '' {
+  if (['income', 'transfer', 'regular'].includes(tx.transaction_type)) {
+    return tx.transaction_type as TransactionType;
+  }
+  // Legacy mappings
+  if (tx.transaction_type === 'debit') return 'regular';
+  // 'credit_payment' was an old enum value before it was merged into 'transfer'
+  if (tx.transaction_type === 'transfer' || (tx.transaction_type as string) === 'credit_payment') return 'transfer';
+  if (tx.transaction_type === 'credit') {
+    return tx.inflow > 0 && !tx.category ? 'income' : 'regular';
+  }
+  // Blank — infer from data
+  if (tx.inflow > 0 && !tx.category) return 'income';
+  if (tx.transfer_pair_id) return 'transfer';
+  if (tx.outflow > 0 || (tx.inflow > 0 && tx.category)) return 'regular';
+  return '';
+}
+
+/**
+ * Scan a list of transactions for a matching transfer pair.
+ * Looks for a different-account transaction within ±7 days with the same amount (±$0.01).
+ */
+export function findTransferPair(
+  tx: Transaction,
+  allTxns: Transaction[]
+): Transaction | null {
+  const amount = tx.outflow || tx.inflow;
+  const txTime = new Date(tx.date).getTime();
+  return (
+    allTxns.find((other) => {
+      if (other.transaction_id === tx.transaction_id || other.account === tx.account) return false;
+      const otherAmount = other.outflow || other.inflow;
+      if (Math.abs(otherAmount - amount) > 0.01) return false;
+      const daysDiff = Math.abs(new Date(other.date).getTime() - txTime) / 86_400_000;
+      return daysDiff <= 7;
+    }) ?? null
+  );
+}
+
+/**
  * Compute per-category activity (outflow − inflow) for a set of transactions.
- * Transfers are excluded — they have no budget impact.
+ * Transfers and income are excluded — they have no budget category impact.
  */
 export function computeCategoryActivity(
   transactions: Transaction[]
 ): Map<string, number> {
   const map = new Map<string, number>();
   for (const tx of transactions) {
-    if (!tx.category || tx.transaction_type === 'transfer') continue;
+    if (!tx.category || tx.transaction_type === 'transfer' || tx.transaction_type === 'income') continue;
     map.set(tx.category, (map.get(tx.category) ?? 0) + tx.outflow - tx.inflow);
   }
   return map;

--- a/src/app.css
+++ b/src/app.css
@@ -52,7 +52,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 }
 .btn-primary:hover { background: var(--accent-dark); }
 
-/* ── Bottom nav ───────────────────────────────────────────────────────────── */
+/* ── Nav (mobile: bottom tab bar, desktop: left sidebar) ─────────────────── */
 .navbar {
   position: fixed; bottom: 0; left: 0; right: 0; height: var(--nav-height);
   background: var(--surface); border-top: 1px solid var(--border);
@@ -60,9 +60,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   padding: 0 8px;
   padding-bottom: env(safe-area-inset-bottom);
 }
+.navbar-brand { display: none; } /* hidden on mobile */
 .navbar-tabs { display: flex; flex: 1; }
 .nav-item {
-  flex: 1; display: flex; align-items: center; justify-content: center;
+  flex: 1; display: inline-flex; align-items: center; justify-content: center;
   height: 100%; color: var(--text-secondary); text-decoration: none;
   font-size: 14px; font-weight: 500; padding: 8px 0;
 }
@@ -302,36 +303,39 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 
 /* ── Desktop responsive layout (≥ 768px) ─────────────────────────────────── */
 @media (min-width: 768px) {
-  /* App shell: row instead of column so navbar becomes left sidebar */
-  .app { flex-direction: row; }
-
-  /* Sidebar nav */
+  /* Top nav bar */
   .navbar {
-    position: static;
-    flex-direction: column;
-    align-items: stretch;
-    width: var(--sidebar-width);
-    min-width: var(--sidebar-width);
-    height: 100vh;
-    border-top: none;
-    border-right: 1px solid var(--border);
-    padding: 24px 0 16px;
-    overflow-y: auto;
+    top: 0; bottom: auto;
+    height: var(--nav-height);
+    border-top: none; border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    gap: 8px;
   }
-  .navbar-tabs { flex-direction: column; flex: 1; gap: 2px; padding: 0 8px; }
+  .navbar-brand {
+    display: block;
+    font-size: 16px; font-weight: 800; color: var(--accent);
+    letter-spacing: -.3px;
+    padding: 0;
+    margin-right: 16px;
+    white-space: nowrap;
+  }
+  .navbar-tabs { gap: 4px; }
   .nav-item {
-    justify-content: flex-start;
-    padding: 10px 12px;
-    height: auto;
+    flex: none;
+    padding: 0 14px;
     font-size: 15px;
     border-radius: 8px;
-    margin: 0;
   }
   .nav-item.active { background: #eef3fb; }
-  .nav-signout { padding: 10px 20px; text-align: left; }
+  .nav-signout { margin-left: auto; padding: 8px 0; }
 
-  /* Main content no longer needs bottom padding for nav */
-  .main-content { flex: 1; padding-bottom: 0; min-width: 0; }
+  /* Main content: top padding for top nav, no bottom padding */
+  .main-content { padding-bottom: 0; padding-top: var(--nav-height); }
+
+  /* Screen titles are redundant — top nav already shows where you are */
+  .screen-title { display: none; }
+  /* Accounts header is title-only so the whole bar becomes empty — collapse it */
+  .accounts-screen .screen-header { display: none; }
 
   /* Bottom sheets → centered modals */
   .assign-overlay { align-items: center; justify-content: center; }
@@ -383,3 +387,152 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   .plan-group-tab-total { font-size: 12px; font-variant-numeric: tabular-nums; flex-shrink: 0; }
   .plan-group-tab-total.negative { color: var(--negative); }
 }
+
+/* ── Nav badge ────────────────────────────────────────────────────────────── */
+.nav-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  background: #e53935; color: #fff; border-radius: 10px;
+  font-size: 10px; font-weight: 700; line-height: 1;
+  padding: 2px 5px; min-width: 16px;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+
+/* ── Triage banner (Accounts screen) ─────────────────────────────────────── */
+.triage-banner {
+  display: block; width: calc(100% - 32px); margin: 12px 16px 0;
+  background: #fff8e1; border: 1px solid #f9a825; border-radius: 12px;
+  padding: 14px 16px; text-align: left; cursor: pointer;
+  font-size: 15px; font-weight: 600; color: #7d5a00;
+  transition: background .15s;
+}
+.triage-banner:hover { background: #fff3cd; }
+
+/* ── Triage screen ────────────────────────────────────────────────────────── */
+.triage-screen {
+  display: flex; flex-direction: column;
+  min-height: 100%;
+}
+
+.triage-screen .screen-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 16px;
+}
+
+.triage-nav-btn {
+  background: none; border: none; cursor: pointer;
+  font-size: 20px; color: var(--text-secondary); padding: 4px 8px;
+  border-radius: 6px; line-height: 1;
+}
+.triage-nav-btn:hover:not(:disabled) { background: var(--bg); color: var(--text); }
+.triage-nav-btn:disabled { opacity: .3; cursor: not-allowed; }
+
+.triage-nav-arrows { display: flex; gap: 4px; }
+
+.triage-progress {
+  font-size: 13px; color: var(--text-secondary); font-weight: 500;
+}
+
+.triage-card-wrapper {
+  flex: 1; display: flex; align-items: flex-start;
+  padding: 16px;
+}
+
+/* ── Triage card ──────────────────────────────────────────────────────────── */
+.triage-card {
+  width: 100%; background: var(--surface); border-radius: 16px;
+  padding: 20px 16px; box-shadow: 0 2px 12px rgba(0,0,0,.06);
+  display: flex; flex-direction: column; gap: 10px;
+}
+
+.triage-card-type {
+  font-size: 13px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--text-secondary);
+}
+.triage-card--income .triage-card-type { color: var(--positive); }
+.triage-card--transfer .triage-card-type { color: var(--accent); }
+
+.triage-card-amount {
+  font-size: 28px; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.triage-card-amount--positive { color: var(--positive); }
+.triage-card-amount--negative { color: var(--negative); }
+
+.triage-card-payee { font-size: 17px; font-weight: 600; }
+
+.triage-card-meta {
+  display: flex; gap: 12px; font-size: 13px; color: var(--text-secondary);
+}
+
+.triage-pair-match {
+  font-size: 13px; color: var(--accent); font-weight: 500;
+  background: #eef3fb; border-radius: 8px; padding: 6px 10px;
+}
+
+/* ── Category picker ──────────────────────────────────────────────────────── */
+.triage-category-list {
+  max-height: 40vh; overflow-y: auto;
+  border: 1px solid var(--border); border-radius: 10px;
+  display: flex; flex-direction: column;
+}
+
+.triage-category-item {
+  width: 100%; background: none; border: none; border-bottom: 1px solid var(--border);
+  padding: 11px 14px; text-align: left; cursor: pointer; font-size: 14px;
+  color: var(--text); transition: background .1s;
+}
+.triage-category-item:last-child { border-bottom: none; }
+.triage-category-item:hover { background: var(--bg); }
+.triage-category-item.selected { background: #eef3fb; color: var(--accent); font-weight: 600; }
+
+.triage-category-item--rta { color: var(--text-secondary); font-style: italic; }
+.triage-category-item--rta.selected { color: var(--accent); font-style: italic; }
+
+.triage-category-item--suggested { font-weight: 600; background: #f9fbe7; }
+.triage-category-item--suggested.selected { background: #eef3fb; color: var(--accent); }
+
+/* ── Triage actions row ───────────────────────────────────────────────────── */
+.triage-actions { margin-top: 4px; }
+.triage-actions .btn-primary { width: 100%; }
+.triage-actions .btn-primary:disabled { opacity: .45; cursor: not-allowed; }
+
+.triage-escape-hatch {
+  background: none; border: none; cursor: pointer;
+  font-size: 13px; color: var(--text-secondary); text-align: center;
+  padding: 4px 0; align-self: center;
+}
+.triage-escape-hatch:hover { color: var(--text); }
+
+/* ── Type selector pills ──────────────────────────────────────────────────── */
+.triage-type-selector {
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+.triage-type-selector--large { justify-content: center; margin-top: 12px; }
+
+.triage-type-pill {
+  flex: 1; background: var(--bg); border: 1px solid var(--border);
+  border-radius: 10px; padding: 10px 8px; font-size: 14px; font-weight: 600;
+  cursor: pointer; text-align: center; transition: background .1s, border-color .1s;
+}
+.triage-type-pill:hover { background: #eef3fb; border-color: var(--accent); color: var(--accent); }
+
+/* ── Skip row ─────────────────────────────────────────────────────────────── */
+.triage-skip-row {
+  padding: 0 16px 16px; display: flex; justify-content: space-between;
+}
+.btn-ghost {
+  background: none; border: none; cursor: pointer;
+  font-size: 14px; color: var(--text-secondary); padding: 8px 20px;
+}
+.btn-ghost:hover { color: var(--text); }
+.btn-ghost:disabled { opacity: .45; cursor: not-allowed; }
+
+/* ── All caught up ────────────────────────────────────────────────────────── */
+.triage-all-caught-up {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 16px;
+  padding: 32px;
+}
+.triage-caught-up-emoji { font-size: 56px; }
+.triage-caught-up-text { font-size: 22px; font-weight: 700; }
+.triage-all-caught-up .btn-secondary { min-width: 160px; }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,31 +1,24 @@
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-const NAV_ITEMS = [
-  { to: '/plan', label: 'Plan' },
-  { to: '/accounts', label: 'Accounts' },
-  { to: '/reflect', label: 'Reflect' },
-];
-
-/**
- * Fixed bottom navigation bar (mobile-first).
- * Only rendered when the user is authenticated.
- */
-export default function NavBar() {
+export default function NavBar({ unreviewedCount }: { unreviewedCount: number | null }) {
   const { signOut } = useAuth();
+  const badge = unreviewedCount != null && unreviewedCount > 0 ? unreviewedCount : null;
 
   return (
     <nav className="navbar">
+      <div className="navbar-brand">Zero Budget</div>
       <div className="navbar-tabs">
-        {NAV_ITEMS.map(({ to, label }) => (
-          <NavLink
-            key={to}
-            to={to}
-            className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
-          >
-            {label}
-          </NavLink>
-        ))}
+        <NavLink to="/plan" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>
+          Plan
+        </NavLink>
+        <NavLink to="/accounts" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>
+          Accounts
+          {badge && <span className="nav-badge">{badge}</span>}
+        </NavLink>
+        <NavLink to="/reflect" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>
+          Reflect
+        </NavLink>
       </div>
       <button className="nav-signout" onClick={signOut} title="Sign out">
         ⏏

--- a/src/screens/Accounts.tsx
+++ b/src/screens/Accounts.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useSheetSync } from '../hooks/useSheetSync';
 import { SheetsClient } from '../api/client';
@@ -44,8 +45,9 @@ function buildAccountSummaries(transactions: Transaction[]): AccountSummary[] {
   return [...map.values()].sort((a, b) => b.balance - a.balance);
 }
 
-export default function Accounts() {
+export default function Accounts({ unreviewedCount }: { unreviewedCount: number | null }) {
   const { token } = useAuth();
+  const navigate = useNavigate();
   const revision = useSheetSync(token);
   const [accounts, setAccounts] = useState<AccountSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -82,6 +84,12 @@ export default function Accounts() {
 
       {!loading && !error && (
         <>
+          {unreviewedCount != null && unreviewedCount > 0 && (
+            <button className="triage-banner" onClick={() => navigate('/triage')}>
+              {unreviewedCount} transaction{unreviewedCount !== 1 ? 's' : ''} to review →
+            </button>
+          )}
+
           <div className="accounts-total">
             <span className="accounts-total-label">Net Worth (from transactions)</span>
             <span className={`accounts-total-value ${totalBalance < 0 ? 'negative' : ''}`}>

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -1,0 +1,442 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { useSheetSync } from '../hooks/useSheetSync';
+import { SheetsClient } from '../api/client';
+import {
+  fetchTransactions,
+  updateTransactionFields,
+  classifyTransactionType,
+  findTransferPair,
+} from '../api/transactions';
+import { fetchBudgetCategories } from '../api/budget';
+import { Transaction, BudgetCategory, TransactionType } from '../types';
+
+const SHEET_ID = import.meta.env.VITE_GOOGLE_SHEET_ID as string;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 });
+}
+
+function txAmount(tx: Transaction): number {
+  return tx.inflow > 0 ? tx.inflow : tx.outflow;
+}
+
+function txAmountLabel(tx: Transaction): string {
+  const sign = tx.inflow > 0 ? '+' : '-';
+  return `${sign}${fmt(txAmount(tx))}`;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function IncomeCard({
+  tx,
+  onApprove,
+  onTypeOverride,
+  escapeOpen,
+  onToggleEscape,
+  saving,
+}: {
+  tx: Transaction;
+  onApprove: () => void;
+  onTypeOverride: (type: TransactionType) => void;
+  escapeOpen: boolean;
+  onToggleEscape: () => void;
+  saving: boolean;
+}) {
+  return (
+    <div className="triage-card triage-card--income">
+      <div className="triage-card-type">💰 Income</div>
+      <div className="triage-card-amount triage-card-amount--positive">{txAmountLabel(tx)}</div>
+      <div className="triage-card-payee">{tx.payee || tx.description || '(unknown payee)'}</div>
+      <div className="triage-card-meta">
+        <span>{tx.account}</span>
+        <span>{tx.date}</span>
+      </div>
+      <div className="triage-actions">
+        <button className="btn btn-primary" onClick={onApprove} disabled={saving}>
+          {saving ? 'Saving…' : 'Approve'}
+        </button>
+      </div>
+      <button className="triage-escape-hatch" onClick={onToggleEscape}>
+        Not income {escapeOpen ? '▲' : '▾'}
+      </button>
+      {escapeOpen && (
+        <div className="triage-type-selector">
+          <button className="triage-type-pill" onClick={() => onTypeOverride('transfer')}>↔️ Transfer</button>
+          <button className="triage-type-pill" onClick={() => onTypeOverride('regular')}>🛒 Purchase</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TransferCard({
+  tx,
+  pair,
+  onConfirm,
+  onTypeOverride,
+  escapeOpen,
+  onToggleEscape,
+  saving,
+}: {
+  tx: Transaction;
+  pair: Transaction | null;
+  onConfirm: () => void;
+  onTypeOverride: (type: TransactionType) => void;
+  escapeOpen: boolean;
+  onToggleEscape: () => void;
+  saving: boolean;
+}) {
+  return (
+    <div className="triage-card triage-card--transfer">
+      <div className="triage-card-type">↔️ Transfer</div>
+      <div className="triage-card-amount">{txAmountLabel(tx)}</div>
+      <div className="triage-card-payee">{tx.payee || tx.description || '(unknown payee)'}</div>
+      <div className="triage-card-meta">
+        <span>{tx.account}</span>
+        <span>{tx.date}</span>
+      </div>
+      {pair && (
+        <div className="triage-pair-match">Matched with {pair.account}</div>
+      )}
+      <div className="triage-actions">
+        <button className="btn btn-primary" onClick={onConfirm} disabled={saving}>
+          {saving ? 'Saving…' : 'Confirm'}
+        </button>
+      </div>
+      <button className="triage-escape-hatch" onClick={onToggleEscape}>
+        Not a transfer {escapeOpen ? '▲' : '▾'}
+      </button>
+      {escapeOpen && (
+        <div className="triage-type-selector">
+          <button className="triage-type-pill" onClick={() => onTypeOverride('income')}>💰 Income</button>
+          <button className="triage-type-pill" onClick={() => onTypeOverride('regular')}>🛒 Purchase</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PurchaseCard({
+  tx,
+  categories,
+  selectedCategory,
+  onSelectCategory,
+  onAssign,
+  onTypeOverride,
+  escapeOpen,
+  onToggleEscape,
+  saving,
+}: {
+  tx: Transaction;
+  categories: BudgetCategory[];
+  selectedCategory: string;
+  onSelectCategory: (cat: string) => void;
+  onAssign: () => void;
+  onTypeOverride: (type: TransactionType) => void;
+  escapeOpen: boolean;
+  onToggleEscape: () => void;
+  saving: boolean;
+}) {
+  const RTA_VALUE = '__rta__';
+
+  // Build picker: suggested first (if present), then all others
+  const suggested = tx.suggested_category;
+  const others = categories.filter((c) => c.category !== suggested);
+
+  return (
+    <div className="triage-card triage-card--regular">
+      <div className="triage-card-amount triage-card-amount--negative">{txAmountLabel(tx)}</div>
+      <div className="triage-card-payee">{tx.payee || tx.description || '(unknown payee)'}</div>
+      <div className="triage-card-meta">
+        <span>{tx.account}</span>
+        <span>{tx.date}</span>
+      </div>
+
+      <div className="triage-category-list">
+        {/* Ready to Assign option */}
+        <button
+          className={`triage-category-item triage-category-item--rta${selectedCategory === RTA_VALUE ? ' selected' : ''}`}
+          onClick={() => onSelectCategory(RTA_VALUE)}
+        >
+          <em>Ready to Assign</em>
+        </button>
+
+        {/* Suggested category */}
+        {suggested && (
+          <button
+            className={`triage-category-item triage-category-item--suggested${selectedCategory === suggested ? ' selected' : ''}`}
+            onClick={() => onSelectCategory(suggested)}
+          >
+            ★ {suggested}
+          </button>
+        )}
+
+        {/* All other active categories */}
+        {others.map((c) => (
+          <button
+            key={c.category}
+            className={`triage-category-item${selectedCategory === c.category ? ' selected' : ''}`}
+            onClick={() => onSelectCategory(c.category)}
+          >
+            {c.category}
+          </button>
+        ))}
+      </div>
+
+      <div className="triage-actions">
+        <button
+          className="btn btn-primary"
+          onClick={onAssign}
+          disabled={saving || !selectedCategory}
+        >
+          {saving ? 'Saving…' : 'Assign'}
+        </button>
+      </div>
+
+      <button className="triage-escape-hatch" onClick={onToggleEscape}>
+        Not a purchase {escapeOpen ? '▲' : '▾'}
+      </button>
+      {escapeOpen && (
+        <div className="triage-type-selector">
+          <button className="triage-type-pill" onClick={() => onTypeOverride('income')}>💰 Income</button>
+          <button className="triage-type-pill" onClick={() => onTypeOverride('transfer')}>↔️ Transfer</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TypeSelectCard({ onSelect }: { onSelect: (type: TransactionType) => void }) {
+  return (
+    <div className="triage-card triage-card--type-select">
+      <div className="triage-card-type">What type of transaction is this?</div>
+      <div className="triage-type-selector triage-type-selector--large">
+        <button className="triage-type-pill" onClick={() => onSelect('income')}>💰 Income</button>
+        <button className="triage-type-pill" onClick={() => onSelect('transfer')}>↔️ Transfer</button>
+        <button className="triage-type-pill" onClick={() => onSelect('regular')}>🛒 Purchase</button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main screen ──────────────────────────────────────────────────────────────
+
+export default function Triage() {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const revision = useSheetSync(token);
+
+  const [triageQueue, setTriageQueue] = useState<Transaction[]>([]);
+  const [allTxns, setAllTxns] = useState<Transaction[]>([]);
+  const [categories, setCategories] = useState<BudgetCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [index, setIndex] = useState(0);
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [overrideType, setOverrideType] = useState<TransactionType | null>(null);
+  const [escapeOpen, setEscapeOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    const client = new SheetsClient(SHEET_ID, token);
+    setLoading(true);
+    setError(null);
+    try {
+      const [allFetched, cats] = await Promise.all([
+        fetchTransactions(client, { includeSplitChildren: true }),
+        fetchBudgetCategories(client),
+      ]);
+      setAllTxns(allFetched);
+      setTriageQueue(allFetched.filter((t) => !t.reviewed));
+      setCategories(cats);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, revision]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Sync card state whenever we navigate to a different card.
+  // Pre-selects an existing category so already-categorized transactions show it highlighted.
+  useEffect(() => {
+    const tx = triageQueue[index];
+    if (!tx) return;
+    setSelectedCategory(tx.category ?? '');
+    setOverrideType(null);
+    setEscapeOpen(false);
+  }, [index, triageQueue]);
+
+  const advance = () => setIndex((i) => i + 1);
+  const goBack = () => setIndex((i) => Math.max(0, i - 1));
+
+  if (loading) return <div className="screen triage-screen"><div className="state-msg">Loading…</div></div>;
+  if (error) return <div className="screen triage-screen"><div className="state-msg error">{error}</div></div>;
+
+  const total = triageQueue.length;
+  const remaining = total - index;
+
+  if (index >= total) {
+    return (
+      <div className="screen triage-screen">
+        <div className="triage-all-caught-up">
+          <div className="triage-caught-up-emoji">🎉</div>
+          <div className="triage-caught-up-text">All caught up!</div>
+          <button className="btn btn-secondary" onClick={() => navigate('/accounts')}>
+            Back to Accounts
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const tx = triageQueue[index];
+  const effectiveType = overrideType ?? classifyTransactionType(tx);
+  const pair = (effectiveType === 'transfer' && overrideType === 'transfer')
+    ? findTransferPair(tx, allTxns)
+    : tx.transfer_pair_id
+      ? allTxns.find((t) => t.transaction_id === tx.transfer_pair_id) ?? null
+      : null;
+
+  const handleApproveIncome = async () => {
+    if (!token) return;
+    setSaving(true);
+    try {
+      const client = new SheetsClient(SHEET_ID, token);
+      await updateTransactionFields(client, tx._rowIndex, {
+        reviewed: true,
+        transaction_type: 'income',
+        category: '',
+        category_group: '',
+        category_type: '',
+      });
+      advance();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleConfirmTransfer = async () => {
+    if (!token) return;
+    setSaving(true);
+    try {
+      const client = new SheetsClient(SHEET_ID, token);
+      await updateTransactionFields(client, tx._rowIndex, {
+        reviewed: true,
+        transaction_type: 'transfer',
+        ...(pair ? { transfer_pair_id: pair.transaction_id } : {}),
+      });
+      if (pair && !pair.transfer_pair_id) {
+        await updateTransactionFields(client, pair._rowIndex, {
+          transfer_pair_id: tx.transaction_id,
+        });
+      }
+      advance();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAssignPurchase = async () => {
+    if (!token || !selectedCategory) return;
+    setSaving(true);
+    const RTA_VALUE = '__rta__';
+    const isRta = selectedCategory === RTA_VALUE;
+    const chosenCat = isRta ? '' : selectedCategory;
+    const catRecord = categories.find((c) => c.category === chosenCat);
+    try {
+      const client = new SheetsClient(SHEET_ID, token);
+      await updateTransactionFields(client, tx._rowIndex, {
+        reviewed: true,
+        transaction_type: 'regular',
+        category: chosenCat,
+        category_group: catRecord?.category_group ?? '',
+        category_type: catRecord?.category_type ?? '',
+      });
+      advance();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTypeOverride = (type: TransactionType) => {
+    setOverrideType(type);
+    setEscapeOpen(false);
+    setSelectedCategory('');
+  };
+
+  return (
+    <div className="screen triage-screen">
+      <header className="screen-header">
+        <button className="triage-nav-btn" onClick={() => navigate('/accounts')}>✕</button>
+        <div className="triage-progress">{index + 1} of {total}</div>
+        <div className="triage-nav-arrows">
+          <button className="triage-nav-btn" onClick={goBack} disabled={index === 0}>‹</button>
+          <button className="triage-nav-btn" onClick={advance} disabled={index >= total - 1}>›</button>
+        </div>
+      </header>
+
+      <div className="triage-card-wrapper">
+        {effectiveType === '' && (
+          <TypeSelectCard onSelect={handleTypeOverride} />
+        )}
+        {effectiveType === 'income' && (
+          <IncomeCard
+            tx={tx}
+            onApprove={handleApproveIncome}
+            onTypeOverride={handleTypeOverride}
+            escapeOpen={escapeOpen}
+            onToggleEscape={() => setEscapeOpen((o) => !o)}
+            saving={saving}
+          />
+        )}
+        {effectiveType === 'transfer' && (
+          <TransferCard
+            tx={tx}
+            pair={pair}
+            onConfirm={handleConfirmTransfer}
+            onTypeOverride={handleTypeOverride}
+            escapeOpen={escapeOpen}
+            onToggleEscape={() => setEscapeOpen((o) => !o)}
+            saving={saving}
+          />
+        )}
+        {effectiveType === 'regular' && (
+          <PurchaseCard
+            tx={tx}
+            categories={categories}
+            selectedCategory={selectedCategory}
+            onSelectCategory={setSelectedCategory}
+            onAssign={handleAssignPurchase}
+            onTypeOverride={handleTypeOverride}
+            escapeOpen={escapeOpen}
+            onToggleEscape={() => setEscapeOpen((o) => !o)}
+            saving={saving}
+          />
+        )}
+      </div>
+
+      <div className="triage-skip-row">
+        <button className="btn btn-ghost" onClick={goBack} disabled={saving || index === 0}>
+          ‹ Back
+        </button>
+        <button className="btn btn-ghost" onClick={advance} disabled={saving}>
+          Skip ›
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 // ─── Enums / Literals ─────────────────────────────────────────────────────────
 
 export type TransactionStatus = 'cleared' | 'pending' | 'manual';
-export type TransactionType = 'debit' | 'credit' | 'transfer';
+export type TransactionType = 'income' | 'transfer' | 'regular';
 export type CategoryType = 'fluid' | 'fixed_bill' | 'savings_target';
 
 // ─── Core Domain Types ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Triage mode** (#10): card-by-card transaction review screen accessible from the Accounts screen banner and nav badge
- **TransactionType modernisation**: replaced legacy `'debit'|'credit'|'transfer'` enum with semantic `'income'|'transfer'|'regular'`
- **Desktop navigation**: top nav bar on ≥768px with brand, horizontal tabs, and cleaner screen headers

## What changed

### Triage screen (`src/screens/Triage.tsx`)
- `/triage` route shows unreviewed (`reviewed=false`) transactions one at a time
- **Adaptive cards**: income → Approve button; transfer → Confirm with pair detection; purchase → scrollable category picker
- **Escape hatches** on each card type to re-classify inline (e.g. "Not income ▾")
- **Unclassified fallback**: type-selector step for transactions that can't be auto-classified
- **Transfer pair detection**: when a user manually sets type to transfer, scans ±7 days for a same-amount transaction on a different account and links `transfer_pair_id` both ways
- **Bidirectional navigation**: Back / Skip ‹ › buttons; saves only fire on Approve/Confirm/Assign
- **"All caught up 🎉"** state when queue is exhausted
- Queue filter: `reviewed === false` — YNAB imports are excluded because the import script now sets `reviewed=TRUE` (see below)

### TransactionType (`src/types/index.ts`, `src/api/transactions.ts`)
- Enum: `'debit'|'credit'|'transfer'` → `'income'|'transfer'|'regular'`
- `classifyTransactionType(tx)` — derives type from legacy values and raw data; exported for reuse
- `findTransferPair(tx, allTxns)` — exported pair-detection helper
- `computeCategoryActivity()` — updated to also exclude `income` transactions (income has no budget category impact)

### Entry points (`src/screens/Accounts.tsx`, `src/components/NavBar.tsx`, `src/App.tsx`)
- Amber triage banner on Accounts screen when `unreviewedCount > 0`
- Red badge count now inline-flex beside "Accounts" label (was absolute-positioned and overlapping)
- `unreviewedCount` lifted into App.tsx and shared with both NavBar and Accounts (single fetch via `useUnreviewedCount`)
- `/triage` route added, NavBar rendered before `<main>` so DOM order is correct for flex layout

### Desktop nav (`src/app.css`)
- ≥768px: navbar becomes a fixed **top bar** (brand left, tabs centre, sign-out right) instead of a sidebar
- Screen titles hidden on desktop — top nav provides context
- Accounts `screen-header` fully collapsed on desktop (was title-only)
- Plan/Reflect desktop header: month picker + Apply Template only, no redundant title
- Mobile: bottom tab bar and all existing styles unchanged

### YNAB import script (`scripts/import-ynab-transactions.ts`) — on `claude/import-ynab-transactions-SO83t` branch
- `buildRegularTransactionRow`, `buildSplitParentRow`, `buildSplitChildRows` now set `reviewed='TRUE'`
- YNAB transactions were already reviewed in YNAB; importing them as unreviewed caused the triage queue to flood with historical data
- Test updated accordingly

## Test plan
- [ ] `npm test` passes (257 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] Accounts screen shows amber triage banner when unreviewed banksheets transactions exist
- [ ] NavBar badge count appears inline beside "Accounts" label
- [ ] Tapping banner navigates to /triage
- [ ] Income card → Approve marks reviewed=true, transaction_type=income
- [ ] Transfer card → Confirm marks reviewed=true; pair detected and linked when match found within ±7 days
- [ ] Purchase card → category picker shows suggested at top; Assign writes category fields + reviewed=true
- [ ] Escape hatch re-classifies card type inline
- [ ] Back / Skip navigate without writing to sheet
- [ ] "All caught up" shows when queue exhausted; Back to Accounts works
- [ ] Desktop ≥768px: top nav bar visible with brand + tabs; no sidebar
- [ ] Screen titles hidden on desktop; Accounts header collapsed; Plan/Reflect show controls only
- [ ] Mobile: bottom tab bar unchanged, screen titles visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)