### PR TITLE
feat(#67): promote Triage to top-level nav tab with badge count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ function AppInner() {
             path="/accounts"
             element={
               <AuthGate>
-                <Accounts unreviewedCount={unreviewedCount} />
+                <Accounts />
               </AuthGate>
             }
           />

--- a/src/app.css
+++ b/src/app.css
@@ -65,7 +65,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .nav-item {
   flex: 1; display: inline-flex; align-items: center; justify-content: center;
   height: 100%; color: var(--text-secondary); text-decoration: none;
-  font-size: 14px; font-weight: 500; padding: 8px 0;
+  font-size: 13px; font-weight: 500; padding: 8px 0;
 }
 .nav-item.active { color: var(--accent); font-weight: 700; }
 .nav-signout {
@@ -730,15 +730,6 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   font-size: 13px; font-weight: 600; color: #bf360c;
 }
 
-.triage-banner {
-  display: block; width: calc(100% - 32px); margin: 12px 16px 0;
-  background: #fff8e1; border: 1px solid #f9a825; border-radius: 12px;
-  padding: 14px 16px; text-align: left; cursor: pointer;
-  font-size: 15px; font-weight: 600; color: #7d5a00;
-  transition: background .15s;
-}
-.triage-banner:hover { background: #fff3cd; }
-
 /* ── Triage screen ────────────────────────────────────────────────────────── */
 .triage-screen {
   display: flex; flex-direction: column;
@@ -823,6 +814,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .triage-category-item--suggested.selected { background: #eef3fb; color: var(--accent); }
 
 /* ── Triage actions row ───────────────────────────────────────────────────── */
+.triage-view-in-list {
+  background: none; border: none; cursor: pointer; padding: 6px 0 2px;
+  font-size: 13px; color: var(--text-secondary); text-align: left;
+}
+.triage-view-in-list:hover { color: var(--accent); }
 .triage-actions { margin-top: 4px; }
 .triage-actions .btn-primary { width: 100%; }
 .triage-actions .btn-primary:disabled { opacity: .45; cursor: not-allowed; }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -14,6 +14,9 @@ export default function NavBar({ unreviewedCount }: { unreviewedCount: number | 
         </NavLink>
         <NavLink to="/accounts" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>
           Transactions
+        </NavLink>
+        <NavLink to="/triage" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>
+          Triage
           {badge && <span className="nav-badge">{badge}</span>}
         </NavLink>
         <NavLink to="/reflect" className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}>

--- a/src/screens/Accounts.tsx
+++ b/src/screens/Accounts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useLiveQuery } from 'dexie-react-hooks';
 import {
   getRecentTransactions,
@@ -459,8 +459,8 @@ const FILTERS: { key: FilterMode; label: string }[] = [
   { key: 'pending', label: 'Pending' },
 ];
 
-export default function Accounts({ unreviewedCount }: { unreviewedCount: number | null }) {
-  const navigate = useNavigate();
+export default function Accounts() {
+  const location = useLocation();
   const { token } = useAuth();
   const isDesktop = useMediaQuery('(min-width: 768px)');
   const [filter, setFilter] = useState<FilterMode>('all');
@@ -469,6 +469,7 @@ export default function Accounts({ unreviewedCount }: { unreviewedCount: number 
   const [activeFilter, setActiveFilter] = useState<ActiveFilter | null>(null);
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
   const [expandedPairIds, setExpandedPairIds] = useState<Set<string>>(new Set());
+  const highlightId = (location.state as { highlightId?: string } | null)?.highlightId ?? null;
 
   // Debounce rawQuery → debouncedQuery (150ms)
   useEffect(() => {
@@ -512,6 +513,13 @@ export default function Accounts({ unreviewedCount }: { unreviewedCount: number 
     }
     return baseTransactions;
   }, [baseTransactions, activeFilter, debouncedQuery]);
+
+  // Auto-select a transaction navigated to from Triage's "View in list" link
+  useEffect(() => {
+    if (!highlightId || !baseTransactions) return;
+    const tx = baseTransactions.find((t) => t.transaction_id === highlightId);
+    if (tx) setSelectedTx(tx);
+  }, [highlightId, baseTransactions]);
 
   const loading = filteredBySearch === undefined;
 
@@ -614,12 +622,6 @@ export default function Accounts({ unreviewedCount }: { unreviewedCount: number 
       <header className="screen-header">
         <h2 className="screen-title">Transactions</h2>
       </header>
-
-      {unreviewedCount != null && unreviewedCount > 0 && (
-        <button className="triage-banner" onClick={() => navigate('/triage')}>
-          {unreviewedCount} transaction{unreviewedCount !== 1 ? 's' : ''} need categories → Triage
-        </button>
-      )}
 
       <div className="tx-search-wrap">
         <SearchBar

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -40,12 +40,14 @@ function IncomeCard({
   tx,
   onApprove,
   onTypeOverride,
+  onViewInList,
   escapeOpen,
   onToggleEscape,
 }: {
   tx: Transaction;
   onApprove: () => void;
   onTypeOverride: (type: TransactionType) => void;
+  onViewInList: () => void;
   escapeOpen: boolean;
   onToggleEscape: () => void;
 }) {
@@ -58,6 +60,7 @@ function IncomeCard({
         <span>{tx.account}</span>
         <span>{tx.date}</span>
       </div>
+      <button className="triage-view-in-list" onClick={onViewInList}>View in list →</button>
       <div className="triage-actions">
         <button className="btn btn-primary" onClick={onApprove}>
           Approve
@@ -82,6 +85,7 @@ function TransferCard({
   pair,
   onConfirm,
   onTypeOverride,
+  onViewInList,
   escapeOpen,
   onToggleEscape,
 }: {
@@ -89,6 +93,7 @@ function TransferCard({
   pair: Transaction | null;
   onConfirm: () => void;
   onTypeOverride: (type: TransactionType) => void;
+  onViewInList: () => void;
   escapeOpen: boolean;
   onToggleEscape: () => void;
 }) {
@@ -104,6 +109,7 @@ function TransferCard({
       {pair && (
         <div className="triage-pair-match">Matched with {pair.account}</div>
       )}
+      <button className="triage-view-in-list" onClick={onViewInList}>View in list →</button>
       <div className="triage-actions">
         <button className="btn btn-primary" onClick={onConfirm}>
           Confirm
@@ -128,6 +134,7 @@ function CcPaymentCard({
   pair,
   onConfirm,
   onTypeOverride,
+  onViewInList,
   escapeOpen,
   onToggleEscape,
 }: {
@@ -135,6 +142,7 @@ function CcPaymentCard({
   pair: Transaction | null;
   onConfirm: () => void;
   onTypeOverride: (type: TransactionType) => void;
+  onViewInList: () => void;
   escapeOpen: boolean;
   onToggleEscape: () => void;
 }) {
@@ -150,6 +158,7 @@ function CcPaymentCard({
       {pair && (
         <div className="triage-pair-match">Matched with {pair.account}</div>
       )}
+      <button className="triage-view-in-list" onClick={onViewInList}>View in list →</button>
       <div className="triage-actions">
         <button className="btn btn-primary" onClick={onConfirm}>
           Confirm
@@ -177,6 +186,7 @@ function PurchaseCard({
   onSelectCategory,
   onAssign,
   onTypeOverride,
+  onViewInList,
   escapeOpen,
   onToggleEscape,
 }: {
@@ -187,6 +197,7 @@ function PurchaseCard({
   onSelectCategory: (cat: string) => void;
   onAssign: () => void;
   onTypeOverride: (type: TransactionType) => void;
+  onViewInList: () => void;
   escapeOpen: boolean;
   onToggleEscape: () => void;
 }) {
@@ -203,6 +214,7 @@ function PurchaseCard({
         <span>{tx.account}</span>
         <span>{tx.date}</span>
       </div>
+      <button className="triage-view-in-list" onClick={onViewInList}>View in list →</button>
 
       <div className="triage-category-list">
         <button
@@ -428,6 +440,7 @@ export default function Triage() {
             tx={tx}
             onApprove={handleApproveIncome}
             onTypeOverride={handleTypeOverride}
+            onViewInList={() => navigate('/accounts', { state: { highlightId: tx.transaction_id } })}
             escapeOpen={escapeOpen}
             onToggleEscape={() => setEscapeOpen((o) => !o)}
           />
@@ -438,6 +451,7 @@ export default function Triage() {
             pair={pair}
             onConfirm={handleConfirmTransfer}
             onTypeOverride={handleTypeOverride}
+            onViewInList={() => navigate('/accounts', { state: { highlightId: tx.transaction_id } })}
             escapeOpen={escapeOpen}
             onToggleEscape={() => setEscapeOpen((o) => !o)}
           />
@@ -448,6 +462,7 @@ export default function Triage() {
             pair={pair}
             onConfirm={handleConfirmCcPayment}
             onTypeOverride={handleTypeOverride}
+            onViewInList={() => navigate('/accounts', { state: { highlightId: tx.transaction_id } })}
             escapeOpen={escapeOpen}
             onToggleEscape={() => setEscapeOpen((o) => !o)}
           />
@@ -461,6 +476,7 @@ export default function Triage() {
             onSelectCategory={setSelectedCategory}
             onAssign={handleAssignPurchase}
             onTypeOverride={handleTypeOverride}
+            onViewInList={() => navigate('/accounts', { state: { highlightId: tx.transaction_id } })}
             escapeOpen={escapeOpen}
             onToggleEscape={() => setEscapeOpen((o) => !o)}
           />

--- a/tests/unit/Accounts.test.tsx
+++ b/tests/unit/Accounts.test.tsx
@@ -7,6 +7,7 @@ import type { Transaction } from '../../src/types';
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
+  useLocation: () => ({ state: null }),
 }));
 
 vi.mock('../../src/hooks/useAuth', () => ({
@@ -149,7 +150,7 @@ describe('Transactions screen — rendering', () => {
   it('shows loading state while data is undefined', async () => {
     mockGetRecentTransactions.mockReturnValue(new Promise(() => {})); // never resolves — stays undefined
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
     expect(screen.getByText('Loading…')).toBeInTheDocument();
   });
 
@@ -159,7 +160,7 @@ describe('Transactions screen — rendering', () => {
       makeTx({ transaction_id: 'tx2', payee: 'Netflix' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(screen.getByText('Whole Foods')).toBeInTheDocument();
@@ -167,21 +168,9 @@ describe('Transactions screen — rendering', () => {
     });
   });
 
-  it('shows triage banner when unreviewedCount > 0', async () => {
-    const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={3} />);
-    expect(screen.getByText(/3 transactions need categories/i)).toBeInTheDocument();
-  });
-
-  it('hides triage banner when unreviewedCount is 0', async () => {
-    const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={0} />);
-    expect(screen.queryByText(/need categories/i)).not.toBeInTheDocument();
-  });
-
   it('shows All, Unreviewed, and Pending filter chips', async () => {
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Unreviewed' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Pending' })).toBeInTheDocument();
@@ -189,14 +178,29 @@ describe('Transactions screen — rendering', () => {
 
   it('shows a search input', async () => {
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
     expect(screen.getByPlaceholderText(/search payee/i)).toBeInTheDocument();
   });
 
   it('shows scope hint with default range when no search', async () => {
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
     expect(screen.getByText(/last 90 days/i)).toBeInTheDocument();
+  });
+
+  it('opens detail for transaction passed via router state highlightId', async () => {
+    const tx = makeTx({ transaction_id: 'tx-highlight', payee: 'Highlight Co' });
+    mockGetRecentTransactions.mockResolvedValue([tx]);
+    vi.doMock('react-router-dom', () => ({
+      useNavigate: () => vi.fn(),
+      useLocation: () => ({ state: { highlightId: 'tx-highlight' } }),
+    }));
+    const { default: Accounts } = await import('../../src/screens/Accounts');
+    render(<Accounts />);
+    // The detail editor opens, showing the payee in the edit form
+    await waitFor(() => {
+      expect(screen.getAllByText('Highlight Co').length).toBeGreaterThan(1);
+    });
   });
 });
 
@@ -212,7 +216,7 @@ describe('Transactions screen — filter chips', () => {
       makeTx({ transaction_id: 'unrev', payee: 'Unreviewed Co', reviewed: false }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Unreviewed' }));
 
@@ -228,7 +232,7 @@ describe('Transactions screen — filter chips', () => {
       makeTx({ transaction_id: 'pnd', payee: 'Pending Co', status: 'pending' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Pending' }));
 
@@ -244,7 +248,7 @@ describe('Transactions screen — filter chips', () => {
       makeTx({ transaction_id: 'u', payee: 'Netflix', reviewed: false }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Unreviewed' }));
     await waitFor(() => expect(screen.queryByText('Amazon')).not.toBeInTheDocument());
@@ -278,7 +282,7 @@ describe('Transactions screen — search', () => {
       makeTx({ transaction_id: 'a', payee: 'Amazon Prime' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.change(screen.getByPlaceholderText(/search payee/i), { target: { value: 'amazon' } });
 
@@ -294,7 +298,7 @@ describe('Transactions screen — search', () => {
       makeTx({ transaction_id: 'found', payee: 'BGE Electric' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => expect(screen.getByText('Recent Payee')).toBeInTheDocument());
 
@@ -314,7 +318,7 @@ describe('Transactions screen — search', () => {
       makeTx({ transaction_id: 's', payee: 'BGE Electric' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.change(screen.getByPlaceholderText(/search payee/i), { target: { value: 'BGE' } });
     await waitFor(() => expect(screen.getByText('BGE Electric')).toBeInTheDocument());
@@ -330,7 +334,7 @@ describe('Transactions screen — search', () => {
       makeTx({ transaction_id: 'h2', payee: 'BGE Gas' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.change(screen.getByPlaceholderText(/search payee/i), { target: { value: 'BGE' } });
 
@@ -339,7 +343,7 @@ describe('Transactions screen — search', () => {
 
   it('shows "Last 90 days" hint when not searching', async () => {
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
     expect(screen.getByText(/last 90 days/i)).toBeInTheDocument();
   });
 });
@@ -355,7 +359,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'u', payee: 'Unknown Shop', reviewed: false, status: 'cleared' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-row--unreviewed')).toBeInTheDocument();
@@ -367,7 +371,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'p', payee: 'Pending Store', status: 'pending' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-row--pending')).toBeInTheDocument();
@@ -379,7 +383,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'rv', reviewed: true, category: 'Groceries', status: 'cleared' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-reviewed-mark')).toBeInTheDocument();
@@ -391,7 +395,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'unrv', reviewed: false, category: 'Groceries' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(screen.getByText('Groceries')).toBeInTheDocument();
@@ -404,7 +408,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'pd', payee: 'Bank Pending', status: 'pending', date: '2026-05-10' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       const meta = document.querySelector('.tx-meta');
@@ -417,7 +421,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'nc', payee: 'Mystery Store', category: '' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-category--none')).toBeInTheDocument();
@@ -430,7 +434,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'out', outflow: 42.5, inflow: 0 }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-amount--outflow')?.textContent).toBe('-$42.50');
@@ -442,7 +446,7 @@ describe('Transactions screen — visual treatment', () => {
       makeTx({ transaction_id: 'in', outflow: 0, inflow: 1500 }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(document.querySelector('.tx-amount--inflow')?.textContent).toBe('+$1,500.00');
@@ -461,7 +465,7 @@ describe('Transactions screen — detail bottom sheet', () => {
       makeTx({ transaction_id: 'tx1', payee: 'Coffee Shop', category: 'Dining Out' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     const row = await screen.findByRole('button', { name: /Coffee Shop/i });
     fireEvent.click(row);
@@ -474,7 +478,7 @@ describe('Transactions screen — detail bottom sheet', () => {
       makeTx({ transaction_id: 'tx2', payee: 'Trader Joes', category: 'Groceries', outflow: 85, inflow: 0 }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     const row = await screen.findByRole('button', { name: /Trader Joes/i });
     fireEvent.click(row);
@@ -489,7 +493,7 @@ describe('Transactions screen — detail bottom sheet', () => {
       makeTx({ transaction_id: 'tx3', payee: 'Gym' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.click(await screen.findByRole('button', { name: /Gym/i }));
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -503,7 +507,7 @@ describe('Transactions screen — detail bottom sheet', () => {
       makeTx({ transaction_id: 'tx4', payee: 'Target' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.click(await screen.findByRole('button', { name: /Target/i }));
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -533,7 +537,7 @@ describe('Transactions screen — type-ahead search', () => {
       makeTx({ transaction_id: 'child', payee: 'EUMC Laurel', parent_id: 'parent' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     await waitFor(() => {
       expect(screen.getByText('EUMC Laurel')).toBeInTheDocument();
@@ -550,7 +554,7 @@ describe('Transactions screen — type-ahead search', () => {
     mockGetAccountSuggestions.mockResolvedValue([]);
 
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     // Simulate selecting a category suggestion by typing enough to trigger suggestions
     // then clicking the suggestion button (which calls onSelectCategory)
@@ -570,7 +574,7 @@ describe('Transactions screen — type-ahead search', () => {
       makeTx({ transaction_id: 's', payee: 'BGE Electric' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
-    render(<Accounts unreviewedCount={null} />);
+    render(<Accounts />);
 
     fireEvent.change(screen.getByPlaceholderText(/search payee/i), { target: { value: 'BGE' } });
     await waitFor(() => expect(screen.getByText('BGE Electric')).toBeInTheDocument());


### PR DESCRIPTION
## Summary

- **Triage is now a first-class nav tab** (Plan | Transactions | Triage | Reflect) with the unreviewed-count badge moved from Transactions to Triage
- **Triage banner removed** from the Accounts screen — superseded by the tab
- **"View in list →"** ghost link on every triage card — navigates to Accounts with that transaction's detail pre-opened via router state
- Mobile nav font nudged 14→13px to fit four tabs cleanly on 375px screens; desktop top-nav unchanged

## What changed

| File | Change |
|---|---|
| `src/components/NavBar.tsx` | Add Triage tab, move badge to it |
| `src/App.tsx` | Drop `unreviewedCount` prop from `<Accounts>` |
| `src/screens/Accounts.tsx` | Remove banner + prop; add `useLocation` highlight logic |
| `src/screens/Triage.tsx` | Add `onViewInList` to all four card types |
| `src/app.css` | 14→13px mobile nav; remove `.triage-banner`; add `.triage-view-in-list` |
| `tests/unit/Accounts.test.tsx` | Remove 2 banner tests; update 28 render calls; add highlight test |

## Test plan

- [x] `npm test` — 422/422 passing
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Mobile preview (375px): 4 tabs fit without wrapping
- [x] Desktop preview: 4 tabs in top nav bar
- [ ] With real data: Triage badge increments/decrements reactively
- [ ] With real data: "View in list →" opens correct transaction detail in Accounts

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)