### PR TITLE
feat(#12): sign out button and expired token handling

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,11 @@
 
 const BASE = 'https://sheets.googleapis.com/v4/spreadsheets';
 
+/** Thrown when the Sheets API returns 401 — token has expired. */
+export class AuthError extends Error {
+  constructor() { super('Session expired'); }
+}
+
 export class SheetsClient {
   private readonly sheetId: string;
   private token: string;
@@ -33,6 +38,8 @@ export class SheetsClient {
         ...options.headers,
       },
     });
+
+    if (res.status === 401) throw new AuthError();
 
     if (!res.ok) {
       let message = `Sheets API ${res.status}`;

--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -10,14 +10,18 @@ interface Props {
  * Otherwise shows a sign-in prompt.
  */
 export default function AuthGate({ children }: Props) {
-  const { isAuthenticated, login } = useAuth();
+  const { isAuthenticated, sessionExpired, login } = useAuth();
 
   if (!isAuthenticated) {
     return (
       <div className="auth-gate">
         <div className="auth-card">
           <h1 className="auth-title">Zero Budget</h1>
-          <p className="auth-subtitle">Sign in with Google to access your budget.</p>
+          <p className="auth-subtitle">
+            {sessionExpired
+              ? 'Session expired — please sign in again.'
+              : 'Sign in with Google to access your budget.'}
+          </p>
           <button className="btn-primary" onClick={() => login()}>
             Sign in with Google
           </button>

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -24,9 +24,13 @@ function getStoredToken(): string | null {
 export interface AuthState {
   token: string | null;
   isAuthenticated: boolean;
+  /** True when the OAuth token expired mid-session (vs. never logged in). */
+  sessionExpired: boolean;
   /** Opens the Google OAuth popup. */
   login: () => void;
   signOut: () => void;
+  /** Called when a 401 is received from the Sheets API. Clears auth and sets sessionExpired. */
+  notifySessionExpired: () => void;
 }
 
 // ─── Context ──────────────────────────────────────────────────────────────────
@@ -43,6 +47,7 @@ const AuthContext = createContext<AuthState | null>(null);
  */
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(getStoredToken);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   const login = useGoogleLogin({
     scope: `${SHEETS_SCOPE} ${DRIVE_METADATA_SCOPE}`,
@@ -50,6 +55,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const expiry = Date.now() + response.expires_in * 1000;
       localStorage.setItem(TOKEN_KEY, response.access_token);
       localStorage.setItem(EXPIRY_KEY, String(expiry));
+      setSessionExpired(false);
       setToken(response.access_token);
     },
     onError: (error) => {
@@ -62,10 +68,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(EXPIRY_KEY);
     setToken(null);
+    setSessionExpired(false);
+  };
+
+  const notifySessionExpired = () => {
+    googleLogout();
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(EXPIRY_KEY);
+    setToken(null);
+    setSessionExpired(true);
   };
 
   return (
-    <AuthContext.Provider value={{ token, isAuthenticated: !!token, login, signOut }}>
+    <AuthContext.Provider value={{ token, isAuthenticated: !!token, sessionExpired, login, signOut, notifySessionExpired }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useSheetSync.ts
+++ b/src/hooks/useSheetSync.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { db } from '../db/schema';
 import { syncOnOpen } from '../db/sync';
+import { AuthError } from '../api/client';
+import { useAuth } from './useAuth';
 
 // `version` is a monotonically increasing integer that increments on every
 // server-side change to the file — much more responsive than `modifiedTime`,
@@ -31,6 +33,7 @@ const DRIVE_FILE_URL = (fileId: string) =>
  *   - If the stored IndexedDB version matches Drive, the sync is skipped entirely.
  */
 export function useSheetSync(token: string | null, intervalMs = 15_000): void {
+  const { notifySessionExpired } = useAuth();
   const disabledRef = useRef(false); // set true if Drive scope is missing (403)
   const syncingRef = useRef(false);  // prevent concurrent syncs
   const sheetId = import.meta.env.VITE_GOOGLE_SHEET_ID as string | undefined;
@@ -82,7 +85,7 @@ export function useSheetSync(token: string | null, intervalMs = 15_000): void {
           return;
         }
 
-        if (res.status === 401) return; // token expired — retry next tick
+        if (res.status === 401) { notifySessionExpired(); return; }
         if (!res.ok) return;            // transient error — retry next tick
 
         const data = (await res.json()) as { version?: string };
@@ -99,9 +102,10 @@ export function useSheetSync(token: string | null, intervalMs = 15_000): void {
         } finally {
           syncingRef.current = false;
         }
-      } catch {
+      } catch (e) {
         syncingRef.current = false;
-        // Network/sync error — ignore, retry on next interval.
+        if (e instanceof AuthError) notifySessionExpired();
+        // else: network/sync error — ignore, retry on next interval.
       }
     }
 

--- a/src/screens/Accounts.tsx
+++ b/src/screens/Accounts.tsx
@@ -13,7 +13,7 @@ import SearchBar, { type ActiveFilter } from '../components/SearchBar';
 import { Transaction, BudgetCategory, TransactionStatus, TransactionType } from '../types';
 import { useAuth } from '../hooks/useAuth';
 import { useMediaQuery } from '../hooks/useMediaQuery';
-import { SheetsClient } from '../api/client';
+import { SheetsClient, AuthError } from '../api/client';
 import { optimisticEditTransaction, optimisticConfirmTransfer } from '../db/optimisticWrites';
 import { classifyTransactionType, findTransferPair, findCcPaymentPair } from '../api/transactions';
 import { getAccountDisplayName } from '../utils/accountNames';
@@ -135,6 +135,7 @@ function TxDetailEditor({
   isDesktop: boolean;
   token: string | null;
 }) {
+  const { notifySessionExpired } = useAuth();
   const [form, setForm] = useState<FormState>(() => initForm(tx));
   const [catFilter, setCatFilter] = useState('');
   const [saving, setSaving] = useState(false);
@@ -175,7 +176,8 @@ function TxDetailEditor({
     try {
       await optimisticEditTransaction(tx, changes, new SheetsClient(SHEET_ID, token));
       onClose();
-    } catch {
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Save failed. Check your connection and try again.');
       setSaving(false);
     }
@@ -201,7 +203,8 @@ function TxDetailEditor({
         form.transaction_type as TransactionType
       );
       onClose();
-    } catch {
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Link failed. Check your connection and try again.');
       setLinkingPair(false);
     }
@@ -219,7 +222,8 @@ function TxDetailEditor({
         await optimisticEditTransaction(pairedTx, { transfer_pair_id: '' }, client);
       }
       onClose();
-    } catch {
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Unlink failed. Check your connection and try again.');
       setLinkingPair(false);
     }

--- a/src/screens/Plan.tsx
+++ b/src/screens/Plan.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useAuth } from '../hooks/useAuth';
 import { useMediaQuery } from '../hooks/useMediaQuery';
-import { SheetsClient } from '../api/client';
+import { SheetsClient, AuthError } from '../api/client';
 import {
   upsertAssignment,
   appendLogEntry,
@@ -50,7 +50,7 @@ interface MoveMoneyState {
 }
 
 export default function Plan() {
-  const { token } = useAuth();
+  const { token, notifySessionExpired } = useAuth();
   const [month, setMonth] = useState(() => toYYYYMM(new Date()));
   const [editState, setEditState] = useState<EditState | null>(null);
   const [moveMoneyState, setMoveMoneyState] = useState<MoveMoneyState | null>(null);
@@ -109,6 +109,7 @@ export default function Plan() {
       await new Promise((r) => setTimeout(r, 800));
       await refreshMonthBudget(token, SHEET_ID);
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setWriteError((e as Error).message);
     } finally {
       setApplyingTemplate(false);
@@ -135,6 +136,7 @@ export default function Plan() {
         _rowIndex: existing?._rowIndex ?? 0,
       });
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setEditState((prev) =>
         prev ? { ...prev, saving: false, saveError: (e as Error).message } : null
       );
@@ -221,6 +223,7 @@ export default function Plan() {
         },
       ]);
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setMoveMoneyState((prev) =>
         prev ? { ...prev, saving: false, saveError: (e as Error).message } : null
       );

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useAuth } from '../hooks/useAuth';
-import { SheetsClient } from '../api/client';
+import { SheetsClient, AuthError } from '../api/client';
 import {
   classifyTransactionType,
   findTransferPair,
@@ -285,7 +285,7 @@ function TypeSelectCard({ onSelect }: { onSelect: (type: TransactionType) => voi
 // ─── Main screen ──────────────────────────────────────────────────────────────
 
 export default function Triage() {
-  const { token } = useAuth();
+  const { token, notifySessionExpired } = useAuth();
   const navigate = useNavigate();
 
   const rawAllTxns = useLiveQuery(() => db.transactions.toArray(), []);
@@ -380,6 +380,7 @@ export default function Triage() {
     try {
       await optimisticApproveIncome(tx, new SheetsClient(SHEET_ID, token));
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Failed to save — change reverted');
     }
   };
@@ -389,6 +390,7 @@ export default function Triage() {
     try {
       await optimisticConfirmTransfer(tx, pair, new SheetsClient(SHEET_ID, token), 'transfer');
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Failed to save — change reverted');
     }
   };
@@ -398,6 +400,7 @@ export default function Triage() {
     try {
       await optimisticConfirmTransfer(tx, pair, new SheetsClient(SHEET_ID, token), 'credit_payment');
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Failed to save — change reverted');
     }
   };
@@ -410,6 +413,7 @@ export default function Triage() {
     try {
       await optimisticAssignPurchase(tx, chosenCat, catRecord, new SheetsClient(SHEET_ID, token));
     } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
       setError('Failed to save — change reverted');
     }
   };


### PR DESCRIPTION
## Summary

- Adds `AuthError` to `client.ts`, thrown on any 401 from the Sheets API, so callers can distinguish session expiry from other failures
- Extends `useAuth` with `sessionExpired` state and `notifySessionExpired()` — clears the token like `signOut` but sets a flag so the UI shows a contextual message
- `AuthGate` shows "Session expired — please sign in again." when the flag is true; normal first-visit message otherwise
- `useSheetSync` calls `notifySessionExpired()` on 401 from the Drive metadata poll and on `AuthError` from `syncOnOpen`
- `Accounts`, `Plan`, and `Triage` screens check `instanceof AuthError` in every write handler before falling through to generic error strings

The sign-out button (⏏) in the NavBar was already wired to `signOut()`, which clears the token and resets `sessionExpired` so the normal sign-in message appears on explicit logout.

## Test plan

- [ ] Sign out via the ⏏ button — should return to sign-in screen with "Sign in with Google to access your budget." message
- [ ] Simulate a 401 by expiring/removing the token from localStorage mid-session, then trigger any write (edit a transaction, assign a category, triage a transaction) — should land on sign-in screen with "Session expired — please sign in again." message
- [ ] Sign back in after session expiry — should clear the expired state and return to the app normally
- [ ] Verify Drive poll 401 path: remove token from localStorage while the app is open (without signing out) — next 15s poll should trigger the expired state

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)