### PR TITLE
feat(#70): add Next Month Runway progress bar to Plan screen

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -105,6 +105,44 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .positive { color: var(--positive); }
 .negative { color: var(--negative) !important; }
 
+/* ── Runway bar ───────────────────────────────────────────────────────────── */
+.runway-bar {
+  display: block; width: 100%; padding: 12px 16px;
+  background: var(--surface); border: none; border-bottom: 1px solid var(--border);
+  text-align: left; cursor: pointer; font: inherit;
+  transition: background .12s;
+}
+.runway-bar:hover { background: #f8faff; }
+
+.runway-bar-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 6px;
+}
+.runway-bar-label {
+  font-size: 11px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .5px; color: var(--text-secondary);
+}
+.runway-bar-pct {
+  font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.runway-track {
+  height: 10px; background: #e0e0e0; border-radius: 5px; overflow: hidden;
+  margin-bottom: 6px;
+}
+.runway-fill {
+  height: 100%; border-radius: 5px;
+  transition: width .4s ease;
+}
+.runway-bar--green .runway-fill { background: var(--positive); }
+.runway-bar--green .runway-bar-pct { color: var(--positive); }
+.runway-bar--yellow .runway-fill { background: #d4900a; }
+.runway-bar--yellow .runway-bar-pct { color: #d4900a; }
+.runway-bar--red .runway-fill { background: var(--negative); }
+.runway-bar--red .runway-bar-pct { color: var(--negative); }
+.runway-bar-sub {
+  font-size: 12px; color: var(--text-secondary);
+}
+
 /* ── Plan screen ──────────────────────────────────────────────────────────── */
 .budget-summary {
   display: flex; gap: 0; background: var(--surface);

--- a/src/components/RunwayBar.tsx
+++ b/src/components/RunwayBar.tsx
@@ -1,0 +1,69 @@
+import { runwayProgress, stillNeeded, estFundedDate, runwayColor } from '../utils/runway';
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}
+
+function fmtDate(d: Date): string {
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric' });
+}
+
+interface RunwayBarProps {
+  currentRTA: number;
+  templateTotal: number;
+  avgDailyIncome: number;
+  nextMonthName: string;
+  onTap: () => void;
+}
+
+export default function RunwayBar({
+  currentRTA,
+  templateTotal,
+  avgDailyIncome,
+  nextMonthName,
+  onTap,
+}: RunwayBarProps) {
+  if (templateTotal <= 0) return null;
+
+  const progress = runwayProgress(currentRTA, templateTotal);
+  const pct = Math.round(progress * 100);
+  const needed = stillNeeded(currentRTA, templateTotal);
+  const color = runwayColor(progress);
+  const isFunded = progress >= 1;
+  const estDate = needed > 0 ? estFundedDate(needed, avgDailyIncome) : null;
+
+  let subtext: string;
+  if (isFunded) {
+    subtext = `Next month fully covered · RTA: ${fmt(currentRTA)}`;
+  } else {
+    const parts = [`Need ${fmt(needed)} more`];
+    if (estDate) {
+      parts.push(`Est. funded ${fmtDate(estDate)}`);
+    } else {
+      parts.push('Behind pace');
+    }
+    subtext = parts.join(' · ');
+  }
+
+  return (
+    <button
+      type="button"
+      className={`runway-bar runway-bar--${color}`}
+      onClick={onTap}
+    >
+      <div className="runway-bar-header">
+        <span className="runway-bar-label">{nextMonthName} RUNWAY</span>
+        <span className="runway-bar-pct">{pct}%{isFunded ? ' ✅' : ''}</span>
+      </div>
+      <div className="runway-track">
+        <div className="runway-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="runway-bar-sub">{subtext}</div>
+    </button>
+  );
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -115,6 +115,19 @@ export async function getSuggestedCategory(payee: string): Promise<string | null
   return matches[0].category;
 }
 
+export async function getAvgDailyIncome(days: number = 90): Promise<number> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const results = await db.transactions
+    .where('date')
+    .aboveOrEqual(cutoffStr)
+    .filter((t) => !t.parent_id && t.transaction_type === 'income')
+    .toArray();
+  const totalInflow = results.reduce((s, t) => s + t.inflow, 0);
+  return totalInflow / days;
+}
+
 export async function getBudgetForMonth(month: string): Promise<GroupedBudget[]> {
   const [categories, assignments, calcs] = await Promise.all([
     getActiveBudgetCategories(),

--- a/src/screens/Plan.tsx
+++ b/src/screens/Plan.tsx
@@ -11,9 +11,10 @@ import {
   batchAppendLogEntries,
 } from '../api/budget';
 import { db } from '../db/schema';
-import { getBudgetForMonth, getMonthAssignments, getActiveBudgetCategories } from '../db/queries';
+import { getBudgetForMonth, getMonthAssignments, getActiveBudgetCategories, getAvgDailyIncome } from '../db/queries';
 import { refreshMonthBudget } from '../db/sync';
 import { GroupedBudget, BudgetAssignment, BudgetCategory, CategoryWithActivity } from '../types';
+import RunwayBar from '../components/RunwayBar';
 
 const SHEET_ID = import.meta.env.VITE_GOOGLE_SHEET_ID as string;
 
@@ -63,9 +64,17 @@ export default function Plan() {
   const assignments = useLiveQuery(() => getMonthAssignments(month), [month]) as BudgetAssignment[] | undefined;
   const categories = useLiveQuery(() => getActiveBudgetCategories()) as BudgetCategory[] | undefined;
   const syncMeta = useLiveQuery(() => db.syncMeta.get('all'));
+  const avgDailyIncome = (useLiveQuery(() => getAvgDailyIncome(90)) as number | undefined) ?? 0;
 
   const loading = groups === undefined;
   const readyToAssign = syncMeta?.readyToAssign ?? 0;
+  const templateTotal = (categories ?? []).reduce((s, c) => s + c.monthly_template_amount, 0);
+
+  const nextMonthDate = new Date();
+  nextMonthDate.setDate(1);
+  nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
+  const nextMonthYYYYMM = toYYYYMM(nextMonthDate);
+  const nextMonthName = nextMonthDate.toLocaleString('en-US', { month: 'long' }).toUpperCase();
 
   // Auto-select first group on desktop when data loads
   const firstGroupName = groups?.[0]?.groupName;
@@ -76,6 +85,8 @@ export default function Plan() {
   const totalAssigned = (groups ?? []).reduce((s, g) => s + g.totalAssigned, 0);
   const totalActivity = (groups ?? []).reduce((s, g) => s + g.totalActivity, 0);
   const totalAvailable = (groups ?? []).reduce((s, g) => s + g.totalAvailable, 0);
+
+  const handleRunwayTap = () => setMonth(nextMonthYYYYMM);
 
   const handleRowClick = (cat: CategoryWithActivity) => {
     const existing = (assignments ?? []).find((a) => a.category === cat.category);
@@ -268,6 +279,14 @@ export default function Plan() {
           {fmt(readyToAssign)}
         </span>
       </div>
+
+      <RunwayBar
+        currentRTA={readyToAssign}
+        templateTotal={templateTotal}
+        avgDailyIncome={avgDailyIncome}
+        nextMonthName={nextMonthName}
+        onTap={handleRunwayTap}
+      />
 
       {loading && <div className="state-msg">Loading…</div>}
       {writeError && <div className="state-msg error">{writeError}</div>}

--- a/src/utils/runway.ts
+++ b/src/utils/runway.ts
@@ -1,0 +1,26 @@
+export function runwayProgress(currentRTA: number, templateTotal: number): number {
+  if (templateTotal <= 0) return 0;
+  return Math.min(Math.max(currentRTA / templateTotal, 0), 1);
+}
+
+export function stillNeeded(currentRTA: number, templateTotal: number): number {
+  return Math.max(templateTotal - currentRTA, 0);
+}
+
+export function estFundedDate(
+  stillNeededAmount: number,
+  avgDailyIncome: number,
+  today: Date = new Date(),
+): Date | null {
+  if (avgDailyIncome <= 0 || stillNeededAmount <= 0) return null;
+  const daysToFull = stillNeededAmount / avgDailyIncome;
+  const date = new Date(today);
+  date.setDate(date.getDate() + Math.ceil(daysToFull));
+  return date;
+}
+
+export function runwayColor(progress: number): 'green' | 'yellow' | 'red' {
+  if (progress >= 1) return 'green';
+  if (progress >= 0.75) return 'yellow';
+  return 'red';
+}

--- a/tests/unit/Plan.test.tsx
+++ b/tests/unit/Plan.test.tsx
@@ -29,6 +29,7 @@ vi.mock('dexie-react-hooks', async () => {
 const mockGetBudgetForMonth = vi.fn().mockResolvedValue([]);
 const mockGetMonthAssignments = vi.fn().mockResolvedValue([]);
 const mockGetActiveBudgetCategories = vi.fn().mockResolvedValue([]);
+const mockGetAvgDailyIncome = vi.fn().mockResolvedValue(0);
 const mockDbSyncMetaGet = vi.fn().mockResolvedValue({ readyToAssign: 0 });
 const mockDbAssignmentsPut = vi.fn().mockResolvedValue(undefined);
 const mockDbAssignmentsBulkPut = vi.fn().mockResolvedValue(undefined);
@@ -37,6 +38,7 @@ vi.mock('../../src/db/queries', () => ({
   getBudgetForMonth: (...args: unknown[]) => mockGetBudgetForMonth(...args),
   getMonthAssignments: (...args: unknown[]) => mockGetMonthAssignments(...args),
   getActiveBudgetCategories: () => mockGetActiveBudgetCategories(),
+  getAvgDailyIncome: () => mockGetAvgDailyIncome(),
 }));
 
 vi.mock('../../src/db/schema', () => ({

--- a/tests/unit/runway.test.ts
+++ b/tests/unit/runway.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { runwayProgress, stillNeeded, estFundedDate, runwayColor } from '../../src/utils/runway';
+
+describe('runwayProgress', () => {
+  it('returns ratio of RTA to template total', () => {
+    expect(runwayProgress(6200, 10000)).toBeCloseTo(0.62);
+  });
+
+  it('caps at 1.0 when RTA exceeds template total', () => {
+    expect(runwayProgress(12000, 10000)).toBe(1);
+  });
+
+  it('returns 0 when RTA is negative', () => {
+    expect(runwayProgress(-100, 10000)).toBe(0);
+  });
+
+  it('returns 0 when template total is 0', () => {
+    expect(runwayProgress(5000, 0)).toBe(0);
+  });
+
+  it('returns exactly 1.0 when RTA equals template total', () => {
+    expect(runwayProgress(10000, 10000)).toBe(1);
+  });
+});
+
+describe('stillNeeded', () => {
+  it('returns difference when RTA < templateTotal', () => {
+    expect(stillNeeded(4000, 10000)).toBe(6000);
+  });
+
+  it('returns 0 when RTA equals templateTotal', () => {
+    expect(stillNeeded(10000, 10000)).toBe(0);
+  });
+
+  it('returns 0 when RTA exceeds templateTotal', () => {
+    expect(stillNeeded(12000, 10000)).toBe(0);
+  });
+
+  it('returns full templateTotal when RTA is 0', () => {
+    expect(stillNeeded(0, 10000)).toBe(10000);
+  });
+});
+
+describe('estFundedDate', () => {
+  it('returns null when avgDailyIncome is 0', () => {
+    expect(estFundedDate(5000, 0)).toBeNull();
+  });
+
+  it('returns null when still needed is 0', () => {
+    expect(estFundedDate(0, 100)).toBeNull();
+  });
+
+  it('calculates correct estimate from a fixed date', () => {
+    const today = new Date('2026-05-26');
+    // 1000 needed at 100/day = 10 days → Jun 5
+    const result = estFundedDate(1000, 100, today);
+    expect(result?.toISOString().slice(0, 10)).toBe('2026-06-05');
+  });
+
+  it('ceils fractional days', () => {
+    const today = new Date('2026-05-26');
+    // 1050 / 100 = 10.5 → ceil = 11 → Jun 6
+    const result = estFundedDate(1050, 100, today);
+    expect(result?.toISOString().slice(0, 10)).toBe('2026-06-06');
+  });
+
+  it('returns null when avgDailyIncome is negative', () => {
+    expect(estFundedDate(5000, -10)).toBeNull();
+  });
+});
+
+describe('runwayColor', () => {
+  it('returns green at exactly 100%', () => {
+    expect(runwayColor(1.0)).toBe('green');
+  });
+
+  it('returns green above 100%', () => {
+    expect(runwayColor(1.2)).toBe('green');
+  });
+
+  it('returns yellow at exactly 75%', () => {
+    expect(runwayColor(0.75)).toBe('yellow');
+  });
+
+  it('returns yellow between 75% and 99%', () => {
+    expect(runwayColor(0.9)).toBe('yellow');
+  });
+
+  it('returns red just below 75%', () => {
+    expect(runwayColor(0.74)).toBe('red');
+  });
+
+  it('returns red at 0%', () => {
+    expect(runwayColor(0)).toBe('red');
+  });
+});


### PR DESCRIPTION
Adds a RunwayBar component at the top of the Plan screen that shows
how far current RTA goes toward covering next month's template total.
Color-codes green/yellow/red at 100/75% thresholds, shows estimated
funded date from 90-day avg daily income, and taps to switch to the
next month's plan view.

- src/utils/runway.ts: pure functions for progress, stillNeeded,
  estFundedDate, runwayColor (fully unit tested)
- src/db/queries.ts: getAvgDailyIncome(days) — sums income
  transactions over the last N days, divides by N
- src/components/RunwayBar.tsx: new component, hides when no
  template is configured (templateTotal = 0)
- src/screens/Plan.tsx: wires up RunwayBar between RTA banner and
  summary row; tap handler navigates to next month
- src/app.css: runway bar styles
- tests/unit/runway.test.ts: 20 unit tests covering all pure fns
- tests/unit/Plan.test.tsx: adds getAvgDailyIncome to queries mock