### PR TITLE
feat(#14): split transactions — create, view, and edit split children

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function AppBadge({ onCount }: { onCount: (n: number | null) => void }) {
 /** Inner shell — renders inside AuthProvider so useAuth() works. */
 function AppInner() {
   const { isAuthenticated, token } = useAuth();
-  useSheetSync(token); // Drive polling — writes to IndexedDB; screens react via useLiveQuery
+  const { triggerSync } = useSheetSync(token); // Drive polling — writes to IndexedDB; screens react via useLiveQuery
   const [unreviewedCount, setUnreviewedCount] = useState<number | null>(null);
   const handleCount = useCallback((n: number | null) => setUnreviewedCount(n), []);
 
@@ -32,7 +32,7 @@ function AppInner() {
       {isAuthenticated && <AppBadge onCount={handleCount} />}
       <SyncProgress />
       <OfflineBanner />
-      {isAuthenticated && <NavBar unreviewedCount={unreviewedCount} />}
+      {isAuthenticated && <NavBar unreviewedCount={unreviewedCount} onSyncRequest={triggerSync} />}
       <main className="main-content">
         <Routes>
           <Route path="/" element={<Navigate to="/plan" replace />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -68,14 +68,46 @@ export class SheetsClient {
   }
 
   /** POST — appends rows below the last non-empty row in the range.
-   * Uses OVERWRITE (not INSERT_ROWS) to avoid triggering formula-range
-   * adjustments in dependent sheets (Budget_Calcs SUMIFS) which cause a
-   * brief recalculation gap where reads return stale zero values. */
-  async appendValues(range: string, values: unknown[][]): Promise<void> {
-    await this.request(
-      `/values/${enc(range)}:append?valueInputOption=RAW&insertDataOption=OVERWRITE`,
-      { method: 'POST', body: JSON.stringify({ range, values }) }
+   *
+   * insertDataOption controls how Google Sheets inserts the data:
+   * - OVERWRITE (default): writes to existing empty cells after the last data row.
+   *   Avoids triggering formula-range adjustments in Budget_Calcs SUMIFS, which
+   *   can cause a brief recalculation gap with stale zero values.
+   * - INSERT_ROWS: physically inserts new rows. Prefer OVERWRITE unless rows must
+   *   be guaranteed to appear even when the sheet has no allocated empty rows.
+   *
+   * Note: for the Transactions tab specifically, use appendTransactions() which
+   * avoids the :append endpoint entirely (its table-detection is unreliable on
+   * large sheets) and instead does a getValues read to find the next empty row.
+   */
+  async appendValues(
+    range: string,
+    values: unknown[][],
+    insertDataOption: 'OVERWRITE' | 'INSERT_ROWS' = 'OVERWRITE',
+  ): Promise<void> {
+    const result = await this.request<{
+      tableRange?: string;
+      updates?: { updatedRange?: string; updatedRows?: number; updatedCells?: number };
+    }>(
+      `/values/${enc(range)}:append?valueInputOption=RAW&insertDataOption=${insertDataOption}`,
+      { method: 'POST', body: JSON.stringify({ range, values }) },
     );
+    if (import.meta.env.DEV) {
+      console.log(
+        `[Sheets.append] ${range} (${insertDataOption}): ` +
+        `tableRange=${result?.tableRange}, ` +
+        `updatedRange=${result?.updates?.updatedRange}, ` +
+        `rows=${result?.updates?.updatedRows}, ` +
+        `cells=${result?.updates?.updatedCells}`,
+      );
+    }
+    if (values.length > 0 && (result?.updates?.updatedRows ?? 0) === 0) {
+      throw new Error(
+        `Sheets append wrote 0 rows (${insertDataOption}); ` +
+        `${values.length} row(s) sent to ${range}. ` +
+        `tableRange detected: ${result?.tableRange ?? 'unknown'}`,
+      );
+    }
   }
 
   /** POST — update multiple non-contiguous ranges in a single request. */

--- a/src/api/transactions.ts
+++ b/src/api/transactions.ts
@@ -125,6 +125,23 @@ export async function fetchTransactions(
 }
 
 /**
+ * Find the next empty row in the Transactions sheet by counting occupied rows
+ * in column A (which always has transaction_id set). Row 1 is the header, so
+ * data rows occupy A2:A{N}. Returns N+1 — the first empty row.
+ *
+ * This is used by append functions instead of the Sheets :append endpoint,
+ * because that endpoint's table-detection (tableRange) returns undefined on
+ * large sheets and silently falls back to the anchor cell, writing data at
+ * the wrong position (top of sheet instead of bottom).
+ */
+async function nextTransactionRow(client: SheetsClient): Promise<number> {
+  const result = await client.getValues('Transactions!A:A');
+  // values.length counts every row from A1 (header) through the last non-empty
+  // cell. Adding 1 gives the first empty row after all existing data.
+  return (result.values?.length ?? 1) + 1;
+}
+
+/**
  * Append a new transaction row to the sheet.
  * `transaction_id` should be pre-populated by the caller (e.g. crypto.randomUUID()).
  */
@@ -132,19 +149,23 @@ export async function appendTransaction(
   client: SheetsClient,
   tx: Omit<Transaction, '_rowIndex'>
 ): Promise<void> {
-  await client.appendValues('Transactions!A2', [serializeRow(tx)]);
+  const row = await nextTransactionRow(client);
+  if (import.meta.env.DEV) console.log(`[appendTransaction] → Transactions!A${row}`);
+  await client.updateValues(`Transactions!A${row}`, [serializeRow(tx)]);
 }
 
 /**
- * Append multiple transaction rows in a single API call.
+ * Append multiple transaction rows in a single PUT call.
  * Prefer this over calling appendTransaction() in a loop to avoid rate limits.
  */
 export async function appendTransactions(
   client: SheetsClient,
-  txns: Omit<Transaction, '_rowIndex'>[]
+  txns: Omit<Transaction, '_rowIndex'>[],
 ): Promise<void> {
   if (txns.length === 0) return;
-  await client.appendValues('Transactions!A2', txns.map(serializeRow));
+  const row = await nextTransactionRow(client);
+  if (import.meta.env.DEV) console.log(`[appendTransactions] ${txns.length} row(s) → Transactions!A${row}`);
+  await client.updateValues(`Transactions!A${row}`, txns.map(serializeRow));
 }
 
 /**

--- a/src/app.css
+++ b/src/app.css
@@ -51,6 +51,8 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   transition: background .15s;
 }
 .btn-primary:hover { background: var(--accent-dark); }
+.btn-primary:disabled { background: #b0bec5; cursor: not-allowed; }
+.btn-primary:disabled:hover { background: #b0bec5; }
 
 /* ── Nav (mobile: bottom tab bar, desktop: left sidebar) ─────────────────── */
 .navbar {
@@ -72,6 +74,12 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   background: none; border: none; cursor: pointer; padding: 8px 12px;
   font-size: 18px; color: var(--text-secondary);
 }
+.nav-sync {
+  background: none; border: none; cursor: pointer; padding: 8px 8px;
+  font-size: 18px; color: var(--text-secondary);
+  line-height: 1;
+}
+.nav-sync:hover { color: var(--primary); }
 
 /* ── Screen shell ─────────────────────────────────────────────────────────── */
 .screen { min-height: 100%; }
@@ -384,6 +392,122 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .tx-category--none { color: var(--negative); font-weight: 600; }
 .tx-reviewed-mark { color: var(--positive); font-size: 11px; font-weight: 700; }
 .tx-split-label { font-size: 11px; color: var(--text-secondary); font-weight: 400; }
+
+/* Split expand toggle */
+.tx-split-toggle {
+  display: block;
+  width: 100%;
+  padding: 4px 12px;
+  background: #f0f4ff;
+  border: none;
+  border-bottom: 1px solid #e0e7ff;
+  color: #4f6ef2;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.tx-split-toggle:hover { background: #e5eaff; }
+
+/* Split child rows (indented, muted) */
+.tx-split-child-row {
+  padding: 6px 12px 6px 28px;
+  background: #f8faff;
+  border-bottom: 1px solid #e8ecf8;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  color: #555;
+}
+@media (min-width: 768px) {
+  .tx-split-child-row.tx-desktop-cols { padding-left: 28px; background: #f8faff; }
+}
+
+/* ── SplitEditor component ─────────────────────────────────────────────────── */
+
+/* Padded content wrapper — prevents lines from touching screen edges */
+.split-editor-content { padding: 0 16px 4px; }
+
+.split-line {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 8px;
+  margin-bottom: 8px;
+  background: #fff;
+}
+.split-line-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+/* Wrapper divs are the flex items — inputs inside get width:100% of the wrapper */
+.split-line-payee-wrap { flex: 1; min-width: 0; }
+.split-line-amount-wrap { display: flex; gap: 4px; align-items: center; flex-shrink: 0; }
+.split-line-amount-wrap .tx-edit-input { width: 90px; }
+.split-line-fill-btn {
+  background: none; border: 1px solid #cbd5e1; border-radius: 6px;
+  cursor: pointer; font-size: 13px; color: #4f6ef2;
+  padding: 6px 8px; flex-shrink: 0; line-height: 1;
+}
+.split-line-fill-btn:hover { background: #f0f4ff; }
+.split-line-fill-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.split-line-remove {
+  color: #888; background: none; border: none; cursor: pointer;
+  font-size: 18px; padding: 0 4px; line-height: 1; flex-shrink: 0;
+}
+.split-line-remove:hover { color: var(--negative); }
+.split-line-cat-btn {
+  width: 100%; text-align: left; padding: 6px 8px;
+  border: 1px solid #cbd5e1; border-radius: 4px;
+  background: #f8fafc; color: #64748b; cursor: pointer; font-size: 13px;
+}
+.split-line-cat-btn:hover { background: #f0f4ff; }
+.split-line-cat-btn--selected { color: #1a202c; background: #fff; }
+.split-cat-list { max-height: 160px; }
+.split-add-btn {
+  display: block; width: 100%; padding: 8px;
+  border: 1px dashed #94a3b8; border-radius: 6px;
+  background: transparent; color: #4f6ef2; cursor: pointer;
+  margin-bottom: 12px; font-size: 14px;
+}
+.split-add-btn:hover { background: #f0f4ff; border-color: #4f6ef2; }
+.split-total-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 13px; padding: 10px 0 8px;
+  border-top: 1px solid #e2e8f0;
+}
+.split-total-valid { color: #16a34a; font-weight: 600; }
+.split-total-over  { color: #dc2626; font-weight: 600; }
+.split-total-under { color: #d97706; font-weight: 600; }
+
+/* ── Section title row with optional action button ─────────────────────────── */
+.tx-edit-section-title-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 16px 4px;
+}
+.tx-edit-section-title-row .tx-edit-section-title { padding: 0; }
+/* Small accent button for section-level actions (Split, Modify splits) */
+.btn-ghost--sm {
+  background: none; border: 1px solid var(--accent, #4f6ef2); border-radius: 6px;
+  cursor: pointer; font-size: 12px; font-weight: 600; color: var(--accent, #4f6ef2);
+  padding: 3px 10px; white-space: nowrap;
+}
+.btn-ghost--sm:hover { background: #f0f4ff; }
+.btn-ghost--sm:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* ── Split summary inside TxDetailEditor (already-split transactions) ──────── */
+.tx-edit-split-summary {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0;
+}
+.tx-edit-split-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 16px; border-top: 1px solid #f0f0f0; font-size: 13px;
+}
+.tx-edit-split-payee { flex: 1; min-width: 0; color: var(--text); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tx-edit-split-cat { flex: 1; min-width: 0; color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tx-edit-split-amt { font-variant-numeric: tabular-nums; font-weight: 600; color: var(--negative); flex-shrink: 0; }
 .tx-amount { font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; white-space: nowrap; flex-shrink: 0; }
 .tx-amount--inflow  { color: var(--positive); }
 .tx-amount--outflow { color: var(--negative); }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,9 +1,33 @@
+import { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
+import { useLiveQuery } from 'dexie-react-hooks';
 import { useAuth } from '../hooks/useAuth';
+import { db } from '../db/schema';
 
-export default function NavBar({ unreviewedCount }: { unreviewedCount: number | null }) {
+function useSyncAge(): string {
+  const meta = useLiveQuery(() => db.syncMeta.get('all'));
+  return useMemo(() => {
+    if (!meta?.lastSyncedAt) return '';
+    const diffMs = Date.now() - new Date(meta.lastSyncedAt).getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    return `${Math.floor(diffHr / 24)}d ago`;
+  }, [meta?.lastSyncedAt]);
+}
+
+export default function NavBar({
+  unreviewedCount,
+  onSyncRequest,
+}: {
+  unreviewedCount: number | null;
+  onSyncRequest: () => void;
+}) {
   const { signOut } = useAuth();
   const badge = unreviewedCount != null && unreviewedCount > 0 ? unreviewedCount : null;
+  const syncAge = useSyncAge();
 
   return (
     <nav className="navbar">
@@ -23,6 +47,13 @@ export default function NavBar({ unreviewedCount }: { unreviewedCount: number | 
           Reflect
         </NavLink>
       </div>
+      <button
+        className="nav-sync"
+        onClick={onSyncRequest}
+        title={syncAge ? `Last synced ${syncAge} — tap to sync now` : 'Sync now'}
+      >
+        ↻
+      </button>
       <button className="nav-signout" onClick={signOut} title="Sign out">
         ⏏
       </button>

--- a/src/components/SplitEditor.tsx
+++ b/src/components/SplitEditor.tsx
@@ -1,0 +1,369 @@
+import { useState, useMemo } from 'react';
+import { SheetsClient, AuthError } from '../api/client';
+import { optimisticSplitTransaction, optimisticEditSplitChildren } from '../db/optimisticWrites';
+import { useAuth } from '../hooks/useAuth';
+import type { Transaction, BudgetCategory } from '../types';
+
+const SHEET_ID = import.meta.env.VITE_GOOGLE_SHEET_ID as string;
+
+/**
+ * SplitEditor — create or edit a parent/child split transaction.
+ *
+ * ─── Edge cases captured for future E2E automation (issue #29) ───────────────
+ *
+ * VALIDATION
+ *  1. Amounts don't sum to parent → Save button disabled; indicator shows
+ *     remaining amount in amber (under) or red (over). Balanced ✓ and Save
+ *     enabled only when |remainder| < $0.01.
+ *  2. Zero-amount lines → blocked (each line must be !== 0); keeps Save disabled
+ *     even when totals happen to balance.
+ *  3. Negative amounts in a split line are allowed — e.g. a $41 purchase and a
+ *     −$12.55 return in one $28.45 transaction. Validation uses !== 0, not > 0.
+ *  4. "Balanced ✓" display and Save button disabled-state must always agree;
+ *     previously they could diverge (display showed balanced, button greyed out).
+ *
+ * LINE MANAGEMENT
+ *  5. Minimum two lines enforced — remove button is hidden when only two lines
+ *     remain (regardless of mode).
+ *  6. Edit mode: lines corresponding to existing sheet children (_childId set)
+ *     never show a remove button; only newly added lines can be removed.
+ *  7. "Set Remaining ↓" button is disabled when remainder ≤ 0 (can't fill
+ *     a line by subtracting). If adding remainder to the current amount would
+ *     produce a non-positive result the update is silently skipped.
+ *  8. Category picker — only one picker open at a time; opening a second one
+ *     closes the first.
+ *
+ * PERSISTENCE
+ *  9. Optimistic write order: IndexedDB first → Sheets second. On Sheets
+ *     failure the catch block reverts IndexedDB and re-throws; user sees
+ *     "Save failed" and the split is fully rolled back.
+ * 10. Sheets `:append` endpoint is NOT used for transaction rows. On sheets
+ *     with 28k+ rows the endpoint returns tableRange: undefined and either
+ *     writes 0 rows (OVERWRITE) or inserts at the anchor cell, corrupting row
+ *     order. appendTransactions() now does GET Transactions!A:A → PUT to the
+ *     computed next empty row instead.
+ * 11. Newly created split children have _rowIndex: 0 (placeholder) until the
+ *     next full sync assigns real row indices. optimisticEditSplitChildren
+ *     skips the Sheets updateValues call for any child still at _rowIndex: 0.
+ * 12. IndexedDB orphans (children written locally but never confirmed in
+ *     Sheets) are purged during syncOnOpen, which now deletes records absent
+ *     from the fetched sheet data before bulkPut-ing the fresh snapshot.
+ *
+ * UI / NAVIGATION
+ * 13. Desktop: clicking "Split" on a transaction must not collapse the detail
+ *     panel. Render condition uses (isSelected || splitTx?.id === tx.id)
+ *     rather than isSelected alone.
+ * 14. After saving a split the parent row shows "Split" in the category cell
+ *     (not "Uncategorized") and a ▼ N splits expand toggle.
+ * 15. In edit mode TxDetailEditor shows a split summary and "Modify splits"
+ *     instead of the category picker + "Split" button.
+ * 16. canSplit checks !tx.split_group_id — re-splitting an already-split
+ *     parent is blocked.
+ *
+ * TRIAGE & BUDGET
+ * 17. Split children have reviewed: true so they never appear in Triage.
+ *     Triage queries also filter !parent_id as an additional guard.
+ * 18. Budget_Calcs SUMIFS already filter parent_id = "" — children contribute
+ *     to category activity correctly without double-counting the parent.
+ * 19. Negative-outflow split children reduce the category's activity (net
+ *     spend), which is the correct behaviour for an in-transaction refund.
+ *
+ * SYNC
+ * 20. ↻ NavBar button clears syncMeta.lastSheetVersion and immediately fires
+ *     a Drive version check, allowing an on-demand full re-sync without
+ *     waiting for the 15-second polling interval.
+ */
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 });
+}
+
+type SplitLine = {
+  _key: string;
+  /** Set when this line corresponds to an existing split child (edit mode). */
+  _childId?: string;
+  /** The existing child's sheet row index; 0 = not yet synced. */
+  _childRowIndex?: number;
+  payee: string;
+  category: string;
+  outflow: string;
+};
+
+function makeLine(payee: string, childId?: string, childRowIndex?: number): SplitLine {
+  return {
+    _key: crypto.randomUUID(),
+    _childId: childId,
+    _childRowIndex: childRowIndex,
+    payee,
+    category: '',
+    outflow: '',
+  };
+}
+
+interface SplitEditorProps {
+  parent: Transaction;
+  categories: BudgetCategory[];
+  /** Populated when editing an existing split; omit or pass [] for a new split. */
+  existingChildren?: Transaction[];
+  onClose: () => void;
+  onSaved: () => void;
+  isDesktop: boolean;
+  token: string | null;
+}
+
+export default function SplitEditor({
+  parent,
+  categories,
+  existingChildren = [],
+  onClose,
+  onSaved,
+  isDesktop,
+  token,
+}: SplitEditorProps) {
+  const { notifySessionExpired } = useAuth();
+  const isEditMode = existingChildren.length > 0;
+
+  const [splitLines, setSplitLines] = useState<SplitLine[]>(() => {
+    if (isEditMode) {
+      return existingChildren.map((c) => ({
+        _key: crypto.randomUUID(),
+        _childId: c.transaction_id,
+        _childRowIndex: c._rowIndex,
+        payee: c.payee,
+        category: c.category,
+        outflow: String(c.outflow),
+      }));
+    }
+    return [makeLine(parent.payee), makeLine(parent.payee)];
+  });
+
+  const [openCatKey, setOpenCatKey] = useState<string | null>(null);
+  const [catFilter, setCatFilter] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const splitTotal = splitLines.reduce((sum, l) => sum + (parseFloat(l.outflow) || 0), 0);
+  const remainder = Math.round((parent.outflow - splitTotal) * 100) / 100;
+  const isValid =
+    Math.abs(remainder) < 0.01 &&
+    splitLines.length >= 2 &&
+    // Allow negative amounts (e.g. a refund within the same transaction).
+    // Require only that each line is non-zero and has a category.
+    splitLines.every((l) => l.category !== '' && (parseFloat(l.outflow) || 0) !== 0);
+
+  const filteredCats = useMemo(() => {
+    if (!catFilter) return categories;
+    const q = catFilter.toLowerCase();
+    return categories.filter((c) => c.category.toLowerCase().includes(q));
+  }, [categories, catFilter]);
+
+  function updateLine(key: string, patch: Partial<SplitLine>) {
+    setSplitLines((prev) => prev.map((l) => (l._key === key ? { ...l, ...patch } : l)));
+    setError(null);
+  }
+
+  function removeLine(key: string) {
+    setSplitLines((prev) => prev.filter((l) => l._key !== key));
+  }
+
+  function addLine() {
+    setSplitLines((prev) => [...prev, makeLine(parent.payee)]);
+  }
+
+  function openPicker(key: string) {
+    setOpenCatKey(key);
+    setCatFilter('');
+  }
+
+  function selectCategory(key: string, cat: string) {
+    updateLine(key, { category: cat });
+    setOpenCatKey(null);
+    setCatFilter('');
+  }
+
+  function handleSetRemaining(key: string) {
+    const lineAmount = parseFloat(splitLines.find((l) => l._key === key)?.outflow ?? '0') || 0;
+    const newAmount = Math.round((lineAmount + remainder) * 100) / 100;
+    if (newAmount > 0) updateLine(key, { outflow: String(newAmount) });
+  }
+
+  async function handleSave() {
+    if (!token) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const client = new SheetsClient(SHEET_ID, token);
+      const splits = splitLines.map((l) => {
+        const cat = categories.find((c) => c.category === l.category);
+        return {
+          payee: l.payee,
+          category: l.category,
+          category_group: cat?.category_group ?? '',
+          category_subgroup: cat?.category_subgroup ?? '',
+          category_type: cat?.category_type ?? '',
+          outflow: parseFloat(l.outflow) || 0,
+          _childId: l._childId,
+          _childRowIndex: l._childRowIndex,
+        };
+      });
+
+      if (isEditMode) {
+        await optimisticEditSplitChildren(parent, existingChildren, splits, client);
+      } else {
+        await optimisticSplitTransaction(parent, splits, client);
+      }
+      onSaved();
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
+      setError('Save failed. Check your connection and try again.');
+      setSaving(false);
+    }
+  }
+
+  const totalClass = Math.abs(remainder) < 0.01
+    ? 'split-total-valid'
+    : splitTotal > parent.outflow
+      ? 'split-total-over'
+      : 'split-total-under';
+
+  const formContent = (
+    <div className="split-editor-content">
+      {splitLines.map((line, index) => (
+        <div key={line._key} className="split-line">
+          <div className="split-line-row">
+            {/* Payee — wrapper div is the flex item so width:100% on input works */}
+            <div className="split-line-payee-wrap">
+              <input
+                className="tx-edit-input"
+                placeholder="Payee"
+                value={line.payee}
+                onChange={(e) => updateLine(line._key, { payee: e.target.value })}
+              />
+            </div>
+            {/* Amount + "set remaining" */}
+            <div className="split-line-amount-wrap">
+              <input
+                data-testid={`split-amount-${index}`}
+                className="tx-edit-input"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+                value={line.outflow}
+                onChange={(e) => updateLine(line._key, { outflow: e.target.value })}
+              />
+              {Math.abs(remainder) >= 0.01 && (
+                <button
+                  className="split-line-fill-btn"
+                  title={`Set to remaining (${fmt(remainder > 0 ? remainder : 0)})`}
+                  onClick={() => handleSetRemaining(line._key)}
+                  disabled={remainder <= 0}
+                >
+                  ↓
+                </button>
+              )}
+            </div>
+            {/* Remove — only for new (non-existing) lines */}
+            {!line._childId && splitLines.length > 2 && (
+              <button
+                data-testid="remove-split-row-btn"
+                className="split-line-remove"
+                onClick={() => removeLine(line._key)}
+                title="Remove this split"
+              >
+                ×
+              </button>
+            )}
+          </div>
+
+          {/* Category picker */}
+          <button
+            data-testid={`split-category-${index}`}
+            className={`split-line-cat-btn${line.category ? ' split-line-cat-btn--selected' : ''}`}
+            onClick={() => (openCatKey === line._key ? setOpenCatKey(null) : openPicker(line._key))}
+          >
+            {line.category || 'Pick category…'}
+          </button>
+          {openCatKey === line._key && (
+            <>
+              <input
+                className="tx-edit-cat-filter"
+                placeholder="Search categories…"
+                value={catFilter}
+                onChange={(e) => setCatFilter(e.target.value)}
+                autoFocus
+              />
+              <div className="tx-edit-cat-list split-cat-list">
+                {filteredCats.length === 0 ? (
+                  <div className="tx-edit-cat-none">No categories match.</div>
+                ) : (
+                  filteredCats.map((cat) => (
+                    <button
+                      key={cat.category}
+                      className={`tx-edit-cat-item${line.category === cat.category ? ' tx-edit-cat-item--selected' : ''}`}
+                      onClick={() => selectCategory(line._key, cat.category)}
+                    >
+                      {cat.category}
+                    </button>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      ))}
+
+      <button data-testid="add-split-row-btn" className="split-add-btn" onClick={addLine}>
+        + Add split line
+      </button>
+
+      <div data-testid="split-total-indicator" className="split-total-row">
+        <span>Total: {fmt(splitTotal)} of {fmt(parent.outflow)}</span>
+        <span data-testid="split-remaining-indicator" className={totalClass}>
+          {Math.abs(remainder) < 0.01
+            ? 'Balanced ✓'
+            : remainder > 0
+              ? `${fmt(remainder)} remaining`
+              : `${fmt(-remainder)} over`}
+        </span>
+      </div>
+
+      {error && <div className="tx-edit-error">{error}</div>}
+      <div className="tx-edit-actions">
+        <button
+          data-testid="cancel-splits-btn"
+          className="btn-secondary"
+          onClick={onClose}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+        <button
+          data-testid="save-splits-btn"
+          className="btn-primary"
+          onClick={handleSave}
+          disabled={!isValid || saving}
+        >
+          {saving ? 'Saving…' : isEditMode ? 'Update splits' : 'Save splits'}
+        </button>
+      </div>
+    </div>
+  );
+
+  if (isDesktop) {
+    return <div className="tx-edit-inline split-editor">{formContent}</div>;
+  }
+
+  return (
+    <div className="assign-overlay" onClick={onClose}>
+      <div className="assign-sheet tx-detail-sheet" onClick={(e) => e.stopPropagation()}>
+        <div className="assign-sheet-handle" />
+        <div className="tx-detail-hero">
+          <span className="tx-detail-amount tx-amount--outflow">-{fmt(parent.outflow)}</span>
+          <span className="tx-detail-payee">{parent.payee || parent.description || '(unknown payee)'}</span>
+          <span className="tx-detail-date">{isEditMode ? 'Edit split' : 'Split transaction'}</span>
+        </div>
+        {formContent}
+      </div>
+    </div>
+  );
+}

--- a/src/db/optimisticWrites.ts
+++ b/src/db/optimisticWrites.ts
@@ -1,7 +1,20 @@
 import { db } from './schema';
-import { updateTransactionFields } from '../api/transactions';
+import { updateTransactionFields, appendTransactions } from '../api/transactions';
 import type { SheetsClient } from '../api/client';
 import type { Transaction, BudgetCategory, TransactionType } from '../types';
+
+interface SplitLine {
+  payee: string;
+  category: string;
+  category_group: string;
+  category_subgroup: string;
+  category_type: string;
+  outflow: number;
+  /** Set when editing an existing child row (its transaction_id). */
+  _childId?: string;
+  /** Set when editing an existing child row (its _rowIndex, 0 = unsynced). */
+  _childRowIndex?: number;
+}
 
 /**
  * Approve a transaction as income.
@@ -77,6 +90,170 @@ export async function optimisticEditTransaction(
     await updateTransactionFields(client, tx._rowIndex, changes);
   } catch (e) {
     await db.transactions.put(tx);
+    throw e;
+  }
+}
+
+/**
+ * Convert a single transaction into a split: update the parent and append child rows.
+ * Updates IndexedDB immediately, then writes to Sheets.
+ * On Sheets failure, reverts the parent and deletes the children from IndexedDB.
+ */
+export async function optimisticSplitTransaction(
+  parent: Transaction,
+  splits: SplitLine[],
+  client: SheetsClient
+): Promise<void> {
+  const splitGroupId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const parentUpdates: Partial<Transaction> = {
+    split_group_id: splitGroupId,
+    category: '',
+    category_group: '',
+    category_subgroup: '',
+    category_type: '',
+    reviewed: true,
+  };
+
+  const children: (Omit<Transaction, '_rowIndex'> & { _rowIndex: number })[] = splits.map((s, i) => ({
+    transaction_id: `SPLIT-${parent.transaction_id}-${i + 1}`,
+    parent_id: parent.transaction_id,
+    split_group_id: splitGroupId,
+    source: parent.source,
+    external_id: '',
+    imported_at: now,
+    status: parent.status,
+    date: parent.date,
+    payee: s.payee,
+    description: '',
+    category: s.category,
+    suggested_category: '',
+    category_subgroup: s.category_subgroup,
+    category_group: s.category_group,
+    category_type: s.category_type as Transaction['category_type'],
+    outflow: s.outflow,
+    inflow: 0,
+    account: parent.account,
+    memo: '',
+    transaction_type: 'regular' as TransactionType,
+    transfer_pair_id: '',
+    flag: '',
+    needs_reimbursement: false,
+    reimbursement_amount: 0,
+    matched_id: '',
+    reviewed: true,
+    _rowIndex: 0,
+  }));
+
+  await db.transactions.update(parent.transaction_id, parentUpdates);
+  await db.transactions.bulkPut(children);
+
+  try {
+    // Use INSERT_ROWS so child rows are physically inserted regardless of how
+    // Google Sheets detects the table extent. OVERWRITE can silently no-op if
+    // the anchor detection is thrown off by the parent row's cleared fields.
+    await updateTransactionFields(client, parent._rowIndex, parentUpdates);
+    await appendTransactions(client, children);
+  } catch (e) {
+    await db.transactions.put(parent);
+    await db.transactions.bulkDelete(children.map((c) => c.transaction_id));
+    throw e;
+  }
+}
+
+/**
+ * Edit the split children of an already-split transaction.
+ * Handles: updating existing children in place, appending new ones.
+ * Removing existing children is not supported (requires row deletion).
+ * Children with _rowIndex === 0 (not yet synced) are updated in IndexedDB only.
+ */
+export async function optimisticEditSplitChildren(
+  parent: Transaction,
+  existingChildren: Transaction[],
+  splits: SplitLine[],
+  client: SheetsClient
+): Promise<void> {
+  const now = new Date().toISOString();
+  const existingById = new Map(existingChildren.map((c) => [c.transaction_id, c]));
+
+  // Partition into: update existing vs. create new
+  const toUpdate: Array<{ child: Transaction; changes: Partial<Transaction> }> = [];
+  const toCreate: (Omit<Transaction, '_rowIndex'> & { _rowIndex: number })[] = [];
+
+  for (const split of splits) {
+    if (split._childId && existingById.has(split._childId)) {
+      const child = existingById.get(split._childId)!;
+      toUpdate.push({
+        child,
+        changes: {
+          payee: split.payee,
+          category: split.category,
+          category_group: split.category_group,
+          category_subgroup: split.category_subgroup,
+          category_type: split.category_type as Transaction['category_type'],
+          outflow: split.outflow,
+        },
+      });
+    } else {
+      toCreate.push({
+        transaction_id: `SPLIT-${parent.transaction_id}-X${crypto.randomUUID().slice(0, 8)}`,
+        parent_id: parent.transaction_id,
+        split_group_id: parent.split_group_id,
+        source: parent.source,
+        external_id: '',
+        imported_at: now,
+        status: parent.status,
+        date: parent.date,
+        payee: split.payee,
+        description: '',
+        category: split.category,
+        suggested_category: '',
+        category_subgroup: split.category_subgroup,
+        category_group: split.category_group,
+        category_type: split.category_type as Transaction['category_type'],
+        outflow: split.outflow,
+        inflow: 0,
+        account: parent.account,
+        memo: '',
+        transaction_type: 'regular' as TransactionType,
+        transfer_pair_id: '',
+        flag: '',
+        needs_reimbursement: false,
+        reimbursement_amount: 0,
+        matched_id: '',
+        reviewed: true,
+        _rowIndex: 0,
+      });
+    }
+  }
+
+  // Optimistic IndexedDB writes
+  for (const { child, changes } of toUpdate) {
+    await db.transactions.update(child.transaction_id, changes);
+  }
+  if (toCreate.length > 0) {
+    await db.transactions.bulkPut(toCreate);
+  }
+
+  try {
+    // Sheets writes — skip children with _rowIndex === 0 (unsynced)
+    for (const { child, changes } of toUpdate) {
+      if (child._rowIndex > 0) {
+        await updateTransactionFields(client, child._rowIndex, changes);
+      }
+    }
+    if (toCreate.length > 0) {
+      await appendTransactions(client, toCreate);
+    }
+  } catch (e) {
+    // Revert
+    for (const { child } of toUpdate) {
+      await db.transactions.put(child);
+    }
+    if (toCreate.length > 0) {
+      await db.transactions.bulkDelete(toCreate.map((c) => c.transaction_id));
+    }
     throw e;
   }
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -128,6 +128,13 @@ export async function getAvgDailyIncome(days: number = 90): Promise<number> {
   return totalInflow / days;
 }
 
+export async function getSplitChildren(parentId: string): Promise<Transaction[]> {
+  return db.transactions
+    .where('parent_id')
+    .equals(parentId)
+    .sortBy('transaction_id');
+}
+
 export async function getBudgetForMonth(month: string): Promise<GroupedBudget[]> {
   const [categories, assignments, calcs] = await Promise.all([
     getActiveBudgetCategories(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -27,6 +27,13 @@ export class BudgetDatabase extends Dexie {
       budgetCalcs: '[month+category], month, category',
       syncMeta: 'key',
     });
+    this.version(2).stores({
+      transactions: 'transaction_id, date, category, account, reviewed, transaction_type, status, parent_id, split_group_id',
+      budgetCategories: 'category, category_group, active',
+      budgetAssignments: '[month+category], month, category, source',
+      budgetCalcs: '[month+category], month, category',
+      syncMeta: 'key',
+    });
   }
 }
 

--- a/src/db/sync.ts
+++ b/src/db/sync.ts
@@ -80,6 +80,18 @@ export async function syncOnOpen(
 
     // Fetch all transactions (including split children for complete cache)
     const transactions = await fetchTransactions(client, { includeSplitChildren: true });
+
+    // Remove orphaned IndexedDB records that no longer exist in the sheet.
+    // This cleans up split children that were written optimistically to IndexedDB
+    // but never persisted to Sheets (e.g. due to the OVERWRITE silent-no-op bug).
+    const sheetIds = new Set(transactions.map((t) => t.transaction_id));
+    const localIds = (await db.transactions.toCollection().primaryKeys()) as string[];
+    const orphanIds = localIds.filter((id) => !sheetIds.has(id));
+    if (orphanIds.length > 0) {
+      console.log(`[sync] Purging ${orphanIds.length} orphaned transaction(s) from IndexedDB`);
+      await db.transactions.bulkDelete(orphanIds);
+    }
+
     await db.transactions.bulkPut(transactions);
     notify({
       status: isColdStart ? 'cold-start' : 'syncing',

--- a/src/hooks/useSheetSync.ts
+++ b/src/hooks/useSheetSync.ts
@@ -32,7 +32,7 @@ const DRIVE_FILE_URL = (fileId: string) =>
  *   - Polling pauses automatically when the page is hidden (Page Visibility API).
  *   - If the stored IndexedDB version matches Drive, the sync is skipped entirely.
  */
-export function useSheetSync(token: string | null, intervalMs = 15_000): void {
+export function useSheetSync(token: string | null, intervalMs = 15_000): { triggerSync: () => void } {
   const { notifySessionExpired } = useAuth();
   const disabledRef = useRef(false); // set true if Drive scope is missing (403)
   const syncingRef = useRef(false);  // prevent concurrent syncs
@@ -124,4 +124,20 @@ export function useSheetSync(token: string | null, intervalMs = 15_000): void {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [token, sheetId, intervalMs]);
+
+  /**
+   * Force an immediate re-sync regardless of the cached sheet version.
+   * Clears the stored version so the next check treats the sheet as stale,
+   * then fires the check immediately without waiting for the next poll tick.
+   */
+  function triggerSync() {
+    db.syncMeta.get('all').then((meta) => {
+      const put = meta
+        ? db.syncMeta.put({ ...meta, lastSheetVersion: '' })
+        : Promise.resolve();
+      put.then(() => checkRef.current?.());
+    });
+  }
+
+  return { triggerSync };
 }

--- a/src/screens/Accounts.tsx
+++ b/src/screens/Accounts.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../hooks/useAuth';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { SheetsClient, AuthError } from '../api/client';
 import { optimisticEditTransaction, optimisticConfirmTransfer } from '../db/optimisticWrites';
+import SplitEditor from '../components/SplitEditor';
 import { classifyTransactionType, findTransferPair, findCcPaymentPair } from '../api/transactions';
 import { getAccountDisplayName } from '../utils/accountNames';
 
@@ -128,12 +129,17 @@ function TxDetailEditor({
   onClose,
   isDesktop,
   token,
+  onSplit,
+  splitChildren,
 }: {
   tx: Transaction;
   categories: BudgetCategory[];
   onClose: () => void;
   isDesktop: boolean;
   token: string | null;
+  onSplit?: () => void;
+  /** Existing split children — when present, shows split summary instead of category picker. */
+  splitChildren?: Transaction[];
 }) {
   const { notifySessionExpired } = useAuth();
   const [form, setForm] = useState<FormState>(() => initForm(tx));
@@ -274,30 +280,61 @@ function TxDetailEditor({
 
       {/* Row 2: Category — only shown for regular purchases */}
       {form.transaction_type === 'regular' || form.transaction_type === '' ? (
-        <>
-          <div className="tx-edit-section-title">Category</div>
-          <input
-            className="tx-edit-cat-filter"
-            placeholder="Search categories…"
-            value={catFilter}
-            onChange={(e) => setCatFilter(e.target.value)}
-          />
-          <div className="tx-edit-cat-list">
-            {filteredCats.length === 0 ? (
-              <div className="tx-edit-cat-none">No categories match.</div>
-            ) : (
-              filteredCats.map((cat) => (
-                <button
-                  key={cat.category}
-                  className={`tx-edit-cat-item${form.category === cat.category ? ' tx-edit-cat-item--selected' : ''}`}
-                  onClick={() => setField('category', cat.category)}
-                >
-                  {cat.category}
+        splitChildren && splitChildren.length > 0 ? (
+          /* Already-split: show summary of existing children */
+          <>
+            <div className="tx-edit-section-title-row">
+              <span className="tx-edit-section-title">Split</span>
+              {onSplit && (
+                <button data-testid="split-transaction-btn" className="btn-ghost btn-ghost--sm" onClick={onSplit} disabled={saving}>
+                  Modify splits
                 </button>
-              ))
-            )}
-          </div>
-        </>
+              )}
+            </div>
+            <div className="tx-edit-split-summary">
+              {splitChildren.map((child) => (
+                <div key={child.transaction_id} className="tx-edit-split-row">
+                  <span className="tx-edit-split-payee">{child.payee || tx.payee}</span>
+                  <span className="tx-edit-split-cat">{child.category}</span>
+                  <span className="tx-edit-split-amt">{fmt(child.outflow)}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          /* Normal: category picker with Split button in header */
+          <>
+            <div className="tx-edit-section-title-row">
+              <span className="tx-edit-section-title">Category</span>
+              {onSplit && (
+                <button data-testid="split-transaction-btn" className="btn-ghost btn-ghost--sm" onClick={onSplit} disabled={saving}>
+                  Split
+                </button>
+              )}
+            </div>
+            <input
+              className="tx-edit-cat-filter"
+              placeholder="Search categories…"
+              value={catFilter}
+              onChange={(e) => setCatFilter(e.target.value)}
+            />
+            <div className="tx-edit-cat-list">
+              {filteredCats.length === 0 ? (
+                <div className="tx-edit-cat-none">No categories match.</div>
+              ) : (
+                filteredCats.map((cat) => (
+                  <button
+                    key={cat.category}
+                    className={`tx-edit-cat-item${form.category === cat.category ? ' tx-edit-cat-item--selected' : ''}`}
+                    onClick={() => setField('category', cat.category)}
+                  >
+                    {cat.category}
+                  </button>
+                ))
+              )}
+            </div>
+          </>
+        )
       ) : (
         <>
           <div className="tx-edit-type-note">
@@ -472,7 +509,10 @@ export default function Accounts() {
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [activeFilter, setActiveFilter] = useState<ActiveFilter | null>(null);
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null);
+  const [splitTx, setSplitTx] = useState<Transaction | null>(null);
+  const [splitEditChildren, setSplitEditChildren] = useState<Transaction[]>([]);
   const [expandedPairIds, setExpandedPairIds] = useState<Set<string>>(new Set());
+  const [expandedSplitIds, setExpandedSplitIds] = useState<Set<string>>(new Set());
   const highlightId = (location.state as { highlightId?: string } | null)?.highlightId ?? null;
 
   // Debounce rawQuery → debouncedQuery (150ms)
@@ -502,6 +542,21 @@ export default function Accounts() {
     () => db.budgetCategories.filter((c) => c.active).sortBy('sort_order'),
     []
   ) ?? [];
+
+  const allSplitChildren = useLiveQuery(
+    () => db.transactions.where('parent_id').notEqual('').toArray(),
+    []
+  ) ?? [];
+
+  const splitChildrenMap = useMemo(() => {
+    const map = new Map<string, Transaction[]>();
+    for (const child of allSplitChildren) {
+      const siblings = map.get(child.parent_id) ?? [];
+      siblings.push(child);
+      map.set(child.parent_id, siblings);
+    }
+    return map;
+  }, [allSplitChildren]);
 
   // For category filter + text narrowing: client-side filter since getTransactionsByCategory returns all
   const filteredBySearch = useMemo(() => {
@@ -619,7 +674,20 @@ export default function Accounts() {
     return `Last ${RECENT_DAYS} days · search to see all history`;
   }
 
-  const handleClose = () => setSelectedTx(null);
+  const handleClose = () => { setSelectedTx(null); setSplitTx(null); setSplitEditChildren([]); };
+
+  /** True when the transaction can be split for the first time. */
+  const canSplit = (tx: Transaction) => tx.outflow > 0 && !tx.split_group_id;
+
+  /** True when an already-split transaction can have its splits edited. */
+  const canEditSplit = (tx: Transaction) =>
+    tx.outflow > 0 && !!tx.split_group_id && splitChildrenMap.has(tx.transaction_id);
+
+  /** Opens SplitEditor for new or existing split. */
+  function handleSplit(tx: Transaction) {
+    setSplitTx(tx);
+    setSplitEditChildren(splitChildrenMap.get(tx.transaction_id) ?? []);
+  }
 
   return (
     <div className="screen transactions-screen">
@@ -711,7 +779,7 @@ export default function Accounts() {
                       <>
                         <button
                           className={txDesktopRowClass(tx, isSelected)}
-                          onClick={() => setSelectedTx(isSelected ? null : tx)}
+                          onClick={() => { setSelectedTx(isSelected ? null : tx); setSplitTx(null); setSplitEditChildren([]); }}
                           title={tx.memo || undefined}
                         >
                           <div className="tx-desktop-cols">
@@ -719,13 +787,13 @@ export default function Accounts() {
                             <span className="tx-desktop-cell tx-desktop-cell--secondary" title={tx.account}>{acct}</span>
                             <span className="tx-desktop-cell tx-desktop-cell--payee">
                               {tx.payee || tx.description || '(unknown)'}
-                              {tx.parent_id && <span className="tx-split-label"> (split)</span>}
+                              {tx.split_group_id && !tx.parent_id && <span className="tx-split-label"> (split)</span>}
                               {pairTx && (
                                 <span className="tx-pair-label"> → {getAccountDisplayName(pairTx.account)}</span>
                               )}
                             </span>
-                            <span className={`tx-desktop-cell${!tx.category ? ' tx-desktop-cell--cat-none' : ''}`}>
-                              {tx.category || 'Uncategorized'}
+                            <span className={`tx-desktop-cell${!tx.category && !tx.split_group_id ? ' tx-desktop-cell--cat-none' : ''}`}>
+                              {tx.split_group_id && !tx.parent_id ? 'Split' : (tx.category || 'Uncategorized')}
                             </span>
                             <span className="tx-desktop-cell tx-desktop-cell--secondary">{tx.memo}</span>
                             <span className={`tx-desktop-cell tx-desktop-cell--num${tx.outflow > 0 ? ' tx-desktop-cell--outflow' : ''}`}>
@@ -770,29 +838,62 @@ export default function Accounts() {
                             <span className="tx-desktop-cell" />
                           </div>
                         )}
+                        {splitChildrenMap.has(tx.transaction_id) && (() => {
+                          const splitChildren = splitChildrenMap.get(tx.transaction_id)!;
+                          const isSplitExpanded = expandedSplitIds.has(tx.transaction_id);
+                          return (
+                            <>
+                              <button
+                                className="tx-split-toggle"
+                                onClick={() => setExpandedSplitIds((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(tx.transaction_id)) next.delete(tx.transaction_id);
+                                  else next.add(tx.transaction_id);
+                                  return next;
+                                })}
+                              >
+                                {isSplitExpanded ? `▲ Hide ${splitChildren.length} splits` : `▼ ${splitChildren.length} splits`}
+                              </button>
+                              {isSplitExpanded && splitChildren.map((child) => (
+                                <div key={child.transaction_id} className="tx-split-child-row tx-desktop-cols">
+                                  <span className="tx-desktop-cell tx-desktop-cell--secondary" />
+                                  <span className="tx-desktop-cell tx-desktop-cell--secondary" />
+                                  <span className="tx-desktop-cell tx-desktop-cell--payee tx-desktop-cell--secondary">{child.payee}</span>
+                                  <span className="tx-desktop-cell">{child.category}</span>
+                                  <span className="tx-desktop-cell tx-desktop-cell--secondary">{child.memo}</span>
+                                  <span className="tx-desktop-cell tx-desktop-cell--num tx-desktop-cell--outflow">{child.outflow > 0 ? fmt(child.outflow) : ''}</span>
+                                  <span className="tx-desktop-cell tx-desktop-cell--num" />
+                                  <span className="tx-desktop-cell" />
+                                  <span className="tx-desktop-cell" />
+                                  <span className="tx-desktop-cell" />
+                                </div>
+                              ))}
+                            </>
+                          );
+                        })()}
                       </>
                     ) : (
                       /* ── Mobile: card-style row ── */
                       <>
                         <button
                           className={txRowClass(tx)}
-                          onClick={() => setSelectedTx(isSelected ? null : tx)}
+                          onClick={() => { setSelectedTx(isSelected ? null : tx); setSplitTx(null); setSplitEditChildren([]); }}
                         >
                           <div className="tx-row-main">
                             <span className="tx-payee">
                               {typeIcon && <span className="tx-type-icon">{typeIcon} </span>}
                               {tx.payee || tx.description || '(unknown)'}
-                              {tx.parent_id && <span className="tx-split-label"> (split)</span>}
+                              {tx.split_group_id && !tx.parent_id && <span className="tx-split-label"> (split)</span>}
                               {pairTx && <span className="tx-pair-label"> → {getAccountDisplayName(pairTx.account)}</span>}
                             </span>
                             <span className="tx-meta">
                               {acct} · {tx.status === 'pending' ? '⏳ ' : ''}{tx.date}
                             </span>
-                            <span className={`tx-category${!tx.category ? ' tx-category--none' : ''}`}>
+                            <span className={`tx-category${!tx.category && !tx.split_group_id ? ' tx-category--none' : ''}`}>
                               {tx.reviewed && tx.category && (
                                 <span className="tx-reviewed-mark" aria-hidden="true">✓ </span>
                               )}
-                              {tx.category || 'Uncategorized'}
+                              {tx.split_group_id && !tx.parent_id ? 'Split' : (tx.category || 'Uncategorized')}
                             </span>
                           </div>
                           <span className={`tx-amount${tx.inflow > 0 ? ' tx-amount--inflow' : ' tx-amount--outflow'}`}>
@@ -812,16 +913,56 @@ export default function Accounts() {
                             </span>
                           </div>
                         )}
+                        {splitChildrenMap.has(tx.transaction_id) && (() => {
+                          const splitChildren = splitChildrenMap.get(tx.transaction_id)!;
+                          const isSplitExpanded = expandedSplitIds.has(tx.transaction_id);
+                          return (
+                            <>
+                              <button
+                                className="tx-split-toggle"
+                                onClick={() => setExpandedSplitIds((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(tx.transaction_id)) next.delete(tx.transaction_id);
+                                  else next.add(tx.transaction_id);
+                                  return next;
+                                })}
+                              >
+                                {isSplitExpanded ? `▲ Hide ${splitChildren.length} splits` : `▼ ${splitChildren.length} splits`}
+                              </button>
+                              {isSplitExpanded && splitChildren.map((child) => (
+                                <div key={child.transaction_id} className="tx-split-child-row">
+                                  <span className="tx-payee tx-desktop-cell--secondary">{child.payee}</span>
+                                  <span className={`tx-category${!child.category ? ' tx-category--none' : ''}`}>{child.category}</span>
+                                  <span className="tx-amount tx-amount--outflow">-{fmt(child.outflow)}</span>
+                                </div>
+                              ))}
+                            </>
+                          );
+                        })()}
                       </>
                     )}
-                    {isSelected && isDesktop && (
-                      <TxDetailEditor
-                        tx={selectedTx!}
-                        categories={categories}
-                        onClose={handleClose}
-                        isDesktop={true}
-                        token={token}
-                      />
+                    {isDesktop && (isSelected || splitTx?.transaction_id === tx.transaction_id) && (
+                      splitTx?.transaction_id === tx.transaction_id
+                        ? <SplitEditor
+                            parent={splitTx}
+                            categories={categories}
+                            existingChildren={splitEditChildren}
+                            onClose={() => { setSplitTx(null); setSplitEditChildren([]); }}
+                            onSaved={splitEditChildren.length > 0
+                              ? () => { setSplitTx(null); setSplitEditChildren([]); }
+                              : handleClose}
+                            isDesktop={true}
+                            token={token}
+                          />
+                        : <TxDetailEditor
+                            tx={selectedTx!}
+                            categories={categories}
+                            onClose={handleClose}
+                            isDesktop={true}
+                            token={token}
+                            splitChildren={splitChildrenMap.get(tx.transaction_id)}
+                            onSplit={canSplit(tx) || canEditSplit(tx) ? () => handleSplit(tx) : undefined}
+                          />
                     )}
                   </div>
                 );
@@ -836,6 +977,21 @@ export default function Accounts() {
           tx={selectedTx}
           categories={categories}
           onClose={handleClose}
+          isDesktop={false}
+          token={token}
+          splitChildren={splitChildrenMap.get(selectedTx.transaction_id)}
+          onSplit={canSplit(selectedTx) || canEditSplit(selectedTx) ? () => handleSplit(selectedTx) : undefined}
+        />
+      )}
+      {splitTx && !isDesktop && (
+        <SplitEditor
+          parent={splitTx}
+          categories={categories}
+          existingChildren={splitEditChildren}
+          onClose={() => { setSplitTx(null); setSplitEditChildren([]); }}
+          onSaved={splitEditChildren.length > 0
+            ? () => { setSplitTx(null); setSplitEditChildren([]); setSelectedTx(splitTx); }
+            : handleClose}
           isDesktop={false}
           token={token}
         />

--- a/tests/unit/Accounts.test.tsx
+++ b/tests/unit/Accounts.test.tsx
@@ -25,6 +25,10 @@ vi.mock('../../src/db/schema', () => ({
     },
     transactions: {
       toArray: () => Promise.resolve([]),
+      where: (_field: unknown) => ({
+        notEqual: (_val: unknown) => ({ toArray: () => Promise.resolve([]) }),
+        equals: (_val: unknown) => ({ sortBy: (_key: unknown) => Promise.resolve([]) }),
+      }),
     },
   },
 }));
@@ -36,6 +40,7 @@ vi.mock('../../src/api/client', () => ({
 vi.mock('../../src/db/optimisticWrites', () => ({
   optimisticEditTransaction: vi.fn().mockResolvedValue(undefined),
   optimisticConfirmTransfer: vi.fn().mockResolvedValue(undefined),
+  optimisticSplitTransaction: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('dexie-react-hooks', async () => {
@@ -531,16 +536,16 @@ describe('Transactions screen — type-ahead search', () => {
     mockGetTransactionsByPayee.mockResolvedValue([]);
   });
 
-  it('shows split children with (split) label in payee', async () => {
+  it('shows (split) label on parent rows that have split_group_id set', async () => {
     mockGetRecentTransactions.mockResolvedValue([
-      makeTx({ transaction_id: 'parent', payee: 'Daffy Charitable' }),
-      makeTx({ transaction_id: 'child', payee: 'EUMC Laurel', parent_id: 'parent' }),
+      makeTx({ transaction_id: 'parent', payee: 'Daffy Charitable', split_group_id: 'grp-1', category: '' }),
+      makeTx({ transaction_id: 'other', payee: 'Amazon' }),
     ]);
     const { default: Accounts } = await import('../../src/screens/Accounts');
     render(<Accounts />);
 
     await waitFor(() => {
-      expect(screen.getByText('EUMC Laurel')).toBeInTheDocument();
+      expect(screen.getByText('Daffy Charitable')).toBeInTheDocument();
       expect(document.querySelector('.tx-split-label')).toBeInTheDocument();
     });
   });

--- a/tests/unit/bts-normalize.test.ts
+++ b/tests/unit/bts-normalize.test.ts
@@ -185,10 +185,18 @@ function mockClient(opts: {
   // existingExtIds maps to Transactions!E2:G rows
   const extValues = (opts.existingExtIds ?? []).map(([eid, imp, st]) => [eid, imp, st]);
 
+  // Simulate the column-A occupancy used by nextTransactionRow(): header + one
+  // row per existing transaction so the function returns a sensible next row.
+  const colAValues = [
+    ['transaction_id'],
+    ...Array(opts.existingExtIds?.length ?? 0).fill(['BTS-placeholder']),
+  ];
+
   return {
     getValues: vi.fn().mockImplementation((range: string) => {
       if (range.startsWith('Transactions (BTS)')) return Promise.resolve({ values: btsValues });
       if (range.startsWith('Transactions!E2')) return Promise.resolve({ values: extValues });
+      if (range === 'Transactions!A:A') return Promise.resolve({ values: colAValues });
       return Promise.resolve({ values: [] });
     }),
     appendValues: vi.fn().mockResolvedValue(undefined),
@@ -208,7 +216,10 @@ describe('normalizeBtsTransactions', () => {
     const result = await normalizeBtsTransactions(client);
     expect(result.inserted).toBe(1);
     expect(result.updated).toBe(0);
-    expect(client.appendValues).toHaveBeenCalledOnce();
+    // appendTransactions now uses getValues + updateValues (not appendValues)
+    expect(client.updateValues).toHaveBeenCalledOnce();
+    const [range] = vi.mocked(client.updateValues).mock.calls[0];
+    expect(range).toMatch(/^Transactions!A\d+$/); // e.g. Transactions!A2
   });
 
   it('skips a row whose external_id already exists (cleared, no change)', async () => {
@@ -219,7 +230,6 @@ describe('normalizeBtsTransactions', () => {
     const result = await normalizeBtsTransactions(client);
     expect(result.inserted).toBe(0);
     expect(result.updated).toBe(0);
-    expect(client.appendValues).not.toHaveBeenCalled();
     expect(client.updateValues).not.toHaveBeenCalled();
   });
 
@@ -262,7 +272,7 @@ describe('normalizeBtsTransactions', () => {
     const client = mockClient({ btsRows: [emptyIdRow], existingExtIds: [] });
     const result = await normalizeBtsTransactions(client);
     expect(result.inserted).toBe(0);
-    expect(client.appendValues).not.toHaveBeenCalled();
+    expect(client.updateValues).not.toHaveBeenCalled();
   });
 
   it('inserts multiple new rows and skips duplicates', async () => {
@@ -273,6 +283,9 @@ describe('normalizeBtsTransactions', () => {
     });
     const result = await normalizeBtsTransactions(client);
     expect(result.inserted).toBe(1); // only bts-002 is new
-    expect(client.appendValues).toHaveBeenCalledOnce();
+    // All new rows go in a single updateValues call (one PUT)
+    expect(client.updateValues).toHaveBeenCalledOnce();
+    const [range] = vi.mocked(client.updateValues).mock.calls[0];
+    expect(range).toMatch(/^Transactions!A\d+$/);
   });
 });


### PR DESCRIPTION
## Summary

- **SplitEditor component**: create or edit split children with per-line payee/category/amount; balanced validation (within $0.01), negative amounts allowed (e.g. in-transaction refunds), single-category-picker-open-at-a-time, desktop inline + mobile bottom sheet
- **Persistence fix**: abandoned the Sheets `:append` endpoint for transaction rows (unreliable on large sheets — `tableRange` returns `undefined`, writes land at wrong row). `appendTransactions` now does `GET Transactions!A:A` → `PUT` to the computed next empty row
- **Orphan cleanup**: `syncOnOpen` now diffs local IndexedDB keys against the fetched sheet and `bulkDelete`s phantom children that survived failed Sheets writes
- **Force-sync button**: `↻` in NavBar clears `lastSheetVersion` and triggers an immediate Drive version check; tooltip shows last-sync age

## Test plan

- [ ] Click a regular purchase → TxDetailEditor → "Split" button visible
- [ ] Split into 2+ lines; Save disabled until total balances; negative amount lines (e.g. $41 + -$12.55 = $28.45) accepted and "Balanced ✓" agrees with Save button state
- [ ] Save → parent row shows "▼ N splits" toggle; expanding shows child rows
- [ ] Edit an existing split: "Modify splits" opens SplitEditor pre-populated; can add new lines; existing lines have no remove button
- [ ] Network failure during save → error shown, IndexedDB fully reverted
- [ ] ↻ NavBar button triggers immediate re-sync without clearing browser storage
- [ ] `npm test` — 422 tests pass

## Edge cases documented

See the 20-point comment block at the top of `src/components/SplitEditor.tsx` capturing all scenarios discovered during manual testing (for future E2E automation, issue #29).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)