### PR TITLE
feat(triage): stale manual transaction banner + queue filter fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,18 @@ See **[docs/ynab-sync-runbook.md](docs/ynab-sync-runbook.md)** for the full YNAB
 
 ---
 
+## Data import language
+
+When discussing or implementing data import features, refer to the import process generically (e.g. "the import script", "legacy data import", "external data source") rather than naming YNAB specifically. The exception is code or config that is genuinely YNAB-specific to the data model (e.g. a script named `import-ynab-register.ts` may keep that name). In docs, comments, issue descriptions, and UI copy, keep the language source-agnostic — we may support other import sources in the future and don't want to couple user-facing language to one provider.
+
+---
+
+## User Guide
+
+`docs/USER_GUIDE.md` is the end-user guide for Zero Budget. When implementing a new user-facing feature, add (or update) the relevant section before closing the PR. If the feature is not yet fully built, add a placeholder section with a note and a list of topics to cover when it is.
+
+---
+
 ## What NOT to do
 - Never manually edit the Google Sheet structure — always use setup-sheet.ts
 - Never insert columns in the middle — always append right

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,135 @@
+# Zero Budget — User Guide
+
+This guide explains how to use Zero Budget day-to-day. It's written for a single user (you, Neil) and assumes the app is already set up and syncing.
+
+---
+
+## Table of Contents
+
+1. [Triage](#triage)
+2. [Accounts & Transactions](#accounts--transactions) *(placeholder)*
+3. [Manual Transaction Entry](#manual-transaction-entry) *(placeholder)*
+4. [Budget / Plan](#budget--plan) *(placeholder)*
+5. [Reflect](#reflect) *(placeholder)*
+6. [Syncing with BankToSheets](#syncing-with-banksheets) *(placeholder)*
+
+---
+
+## Triage
+
+Triage is where you review and classify imported transactions. Think of it as your inbox — you work through it until it's empty, then you're done.
+
+### What shows up in Triage
+
+The Triage queue contains any transaction that hasn't been reviewed yet. This includes:
+
+- **Purchases** that need a budget category assigned
+- **Income** that needs to be approved (so it can be assigned to Ready to Assign)
+- **Transfers** between your accounts that need to be confirmed
+- **Credit card payments** that need to be linked
+
+Transactions you entered manually do *not* go into the Triage queue — you already thought about them when you entered them.
+
+### The counter ("X of Y")
+
+The header shows your position in the queue (`1 of 5`, etc.). The number in the nav bar badge matches the total count of items needing your attention, which includes:
+
+- Unreviewed imported transactions (the main queue)
+- Manual transactions that haven't cleared in 14+ days (see [Stale manual transactions](#stale-manual-transactions) below)
+
+### Working through the queue
+
+Each transaction shows as a card. The card type depends on what Zero Budget thinks the transaction is:
+
+| Card type | What it means | Your action |
+|---|---|---|
+| 🛒 Purchase | An expense that needs a category | Pick a category, tap **Assign** |
+| 💰 Income | Money coming in | Tap **Approve** to move it to Ready to Assign |
+| ↔️ Transfer | Money moving between your accounts | Tap **Confirm** |
+| 💳 CC Payment | A credit card payment | Tap **Confirm** |
+| ❓ Unknown | Zero Budget isn't sure | Pick the correct type from the buttons |
+
+**Suggested category:** For purchases, Zero Budget suggests a category based on where you've sent money from this payee before. The suggestion is pre-selected if it exists. You can override it by picking any other category.
+
+**Ready to Assign:** You can also assign a purchase directly to Ready to Assign if you haven't decided on a category yet. It appears as an italic option at the top of the category list.
+
+**Skip:** Use the Skip button (or the › arrow in the header) to come back to a transaction later. You can also navigate backwards with Back / ‹.
+
+**"Not a purchase / income / transfer / CC payment":** If Zero Budget got the type wrong, tap the escape hatch at the bottom of the card to switch it to a different type.
+
+### Stale manual transactions
+
+If you entered a transaction manually (e.g. you wrote a check and logged it immediately) but the bank never imported a matching transaction within 14 days, Zero Budget surfaces a warning banner at the top of Triage:
+
+> ⚠️ 2 manual transactions haven't cleared in 14+ days
+
+Tap the banner to expand the list. For each stale transaction you can:
+
+- **Delete** — remove it entirely if the transaction never happened or was entered in error
+
+If the transaction really did clear but wasn't matched automatically, go to the Accounts screen to find it and link it manually *(linking UI: placeholder — not yet implemented)*.
+
+### When you're done
+
+When all transactions are reviewed, Triage shows a 🎉 "All caught up!" screen. The nav badge disappears. If there are stale manual transactions, the warning banner still appears here as a reminder.
+
+---
+
+## Accounts & Transactions
+
+*(Placeholder — to be written when the Accounts screen is more complete.)*
+
+Topics to cover:
+- Transaction list: filters (All / Unreviewed / Pending), search
+- Unreviewed vs. Pending chips
+- Editing a transaction inline (category, memo, type)
+- The 🔗 matched indicator for manual transactions that cleared
+- Split transactions
+
+---
+
+## Manual Transaction Entry
+
+*(Placeholder — to be written when the manual entry form is built, issue #16.)*
+
+Topics to cover:
+- How to enter a transaction before it clears
+- What "Uncleared" means and how it affects your budget
+- How automatic matching works when BTS imports the cleared version
+- Approving a matched transaction
+- What happens if no match arrives within 14 days
+
+---
+
+## Budget / Plan
+
+*(Placeholder — to be written when the Plan screen is complete.)*
+
+Topics to cover:
+- Assigning money to categories
+- Ready to Assign
+- Group budgets vs. category budgets
+- Rollover
+- Applying a template
+
+---
+
+## Reflect
+
+*(Placeholder — to be written after the Reflect screen is finalized.)*
+
+Topics to cover:
+- Spending overview: time range, pie chart, bar chart
+- Filtering by category
+- What counts as "spending" (transfers and CC payments excluded)
+
+---
+
+## Syncing with BankToSheets
+
+*(Placeholder — see [ynab-sync-runbook.md](ynab-sync-runbook.md) for the YNAB migration runbook.)*
+
+Topics to cover:
+- How BTS syncs automatically
+- What to do when a transaction comes in with the wrong account name
+- Manual re-sync

--- a/src/app.css
+++ b/src/app.css
@@ -1253,6 +1253,63 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .btn-ghost:hover { color: var(--text); }
 .btn-ghost:disabled { opacity: .45; cursor: not-allowed; }
 
+/* ── Stale manual transaction banner ─────────────────────────────────────── */
+.stale-manual-banner {
+  margin: 0 16px 8px;
+  border: 1.5px solid #f59e0b;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fffbeb;
+}
+
+.stale-manual-banner__toggle {
+  width: 100%; background: none; border: none; cursor: pointer;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px; gap: 8px;
+  font-size: 13px; font-weight: 600; color: #92400e; text-align: left;
+}
+.stale-manual-banner__toggle:hover { background: #fef3c7; }
+
+.stale-manual-banner__chevron {
+  font-size: 11px; flex-shrink: 0; color: #b45309;
+}
+
+.stale-manual-list {
+  list-style: none; margin: 0; padding: 0;
+  border-top: 1px solid #fde68a;
+}
+
+.stale-manual-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid #fde68a;
+  background: #fffbeb;
+}
+.stale-manual-item:last-child { border-bottom: none; }
+
+.stale-manual-item__info {
+  flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0;
+}
+.stale-manual-item__payee {
+  font-size: 14px; font-weight: 600; color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.stale-manual-item__meta {
+  font-size: 12px; color: var(--text-secondary);
+}
+
+.stale-manual-item__amount {
+  font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums;
+  color: var(--negative); flex-shrink: 0;
+}
+
+.stale-manual-item__delete {
+  background: none; border: 1px solid #f59e0b; border-radius: 6px;
+  padding: 4px 10px; font-size: 12px; font-weight: 600; color: #b45309;
+  cursor: pointer; flex-shrink: 0;
+}
+.stale-manual-item__delete:hover { background: #fde68a; }
+
 /* ── All caught up ────────────────────────────────────────────────────────── */
 .triage-all-caught-up {
   flex: 1; display: flex; flex-direction: column;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -117,8 +117,18 @@ export async function getTransactionsByCategory(category: string): Promise<Trans
 }
 
 export async function getUnreviewedCount(): Promise<number> {
-  // Dexie indexes booleans as 0/1 — filter() handles the boolean correctly
-  return db.transactions.filter((t) => !t.parent_id && !t.reviewed).count();
+  // Excludes status='manual' transactions — those are pre-entered and don't need triage
+  // until they go stale (14+ days unmatched), counted separately by getStaleManualCount.
+  return db.transactions.filter((t) => !t.parent_id && !t.reviewed && t.status !== 'manual').count();
+}
+
+export async function getStaleManualCount(): Promise<number> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 14);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return db.transactions.filter(
+    (t) => t.status === 'manual' && !t.matched_id && t.date <= cutoffStr
+  ).count();
 }
 
 export async function getActiveBudgetCategories(): Promise<BudgetCategory[]> {

--- a/src/hooks/useUnreviewedCount.ts
+++ b/src/hooks/useUnreviewedCount.ts
@@ -1,7 +1,9 @@
 import { useLiveQuery } from 'dexie-react-hooks';
-import { getUnreviewedCount } from '../db/queries';
+import { getUnreviewedCount, getStaleManualCount } from '../db/queries';
 
 export function useUnreviewedCount(): number | null {
-  const count = useLiveQuery(() => getUnreviewedCount());
-  return count ?? null;
+  const unreviewed = useLiveQuery(() => getUnreviewedCount());
+  const staleManual = useLiveQuery(() => getStaleManualCount());
+  if (unreviewed === undefined || staleManual === undefined) return null;
+  return unreviewed + staleManual;
 }

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -289,7 +289,7 @@ function StaleManualBanner({ txns, onDelete }: { txns: Transaction[]; onDelete: 
   return (
     <div className="stale-manual-banner">
       <button className="stale-manual-banner__toggle" onClick={() => setOpen((o) => !o)}>
-        <span>⚠️ {txns.length} manual {txns.length === 1 ? 'transaction hasn't' : 'transactions haven't'} cleared in {STALE_DAYS}+ days</span>
+        <span>⚠️ {txns.length} manual {txns.length === 1 ? "transaction hasn't" : "transactions haven't"} cleared in {STALE_DAYS}+ days</span>
         <span className="stale-manual-banner__chevron">{open ? '▲' : '▾'}</span>
       </button>
       {open && (

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -389,6 +389,20 @@ export default function Triage() {
   const advance = () => setIndex((i) => i + 1);
   const goBack = () => setIndex((i) => Math.max(0, i - 1));
 
+  // Must be declared before any early returns so hook call order is stable.
+  const handleDeleteStaleManual = useCallback(async (tx: Transaction) => {
+    if (!token) return;
+    if (!confirm(`Delete "${tx.payee || 'this transaction'}" (${tx.outflow > 0 ? fmt(tx.outflow) : fmt(tx.inflow)})?`)) return;
+    try {
+      await db.transactions.delete(tx.transaction_id);
+      const client = new SheetsClient(SHEET_ID, token);
+      await client.updateValues(`Transactions!A${tx._rowIndex}`, [['']] );
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
+      setError('Failed to delete — please try again');
+    }
+  }, [token, notifySessionExpired]);
+
   if (rawAllTxns === undefined || rawCategories === undefined) {
     return <div className="screen triage-screen"><div className="state-msg">Loading…</div></div>;
   }
@@ -479,21 +493,6 @@ export default function Triage() {
     setEscapeOpen(false);
     setSelectedCategory('');
   };
-
-  const handleDeleteStaleManual = useCallback(async (tx: Transaction) => {
-    if (!token) return;
-    if (!confirm(`Delete "${tx.payee || 'this transaction'}" (${tx.outflow > 0 ? fmt(tx.outflow) : fmt(tx.inflow)})?`)) return;
-    try {
-      // Remove from IndexedDB optimistically; also clear from sheet
-      await db.transactions.delete(tx.transaction_id);
-      const client = new SheetsClient(SHEET_ID, token);
-      // Clear the row by blanking the transaction_id column — keep row intact to avoid shifting
-      await client.updateValues(`Transactions!A${tx._rowIndex}`, [['']] );
-    } catch (e) {
-      if (e instanceof AuthError) { notifySessionExpired(); return; }
-      setError('Failed to delete — please try again');
-    }
-  }, [token, notifySessionExpired]);
 
   return (
     <div className="screen triage-screen">

--- a/src/screens/Triage.tsx
+++ b/src/screens/Triage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useAuth } from '../hooks/useAuth';
@@ -8,7 +8,7 @@ import {
   findTransferPair,
   findCcPaymentPair,
 } from '../api/transactions';
-import { getActiveBudgetCategories, getSuggestedCategory } from '../db/queries';
+import { getActiveBudgetCategories, getSuggestedCategory, getStaleManualCount } from '../db/queries';
 import {
   optimisticApproveIncome,
   optimisticConfirmTransfer,
@@ -273,6 +273,47 @@ function PurchaseCard({
   );
 }
 
+// ─── Stale manual transaction banner ─────────────────────────────────────────
+
+const STALE_DAYS = 14;
+
+function staleCutoff(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - STALE_DAYS);
+  return d.toISOString().slice(0, 10);
+}
+
+function StaleManualBanner({ txns, onDelete }: { txns: Transaction[]; onDelete: (tx: Transaction) => void }) {
+  const [open, setOpen] = useState(false);
+  if (txns.length === 0) return null;
+  return (
+    <div className="stale-manual-banner">
+      <button className="stale-manual-banner__toggle" onClick={() => setOpen((o) => !o)}>
+        <span>⚠️ {txns.length} manual {txns.length === 1 ? 'transaction hasn't' : 'transactions haven't'} cleared in {STALE_DAYS}+ days</span>
+        <span className="stale-manual-banner__chevron">{open ? '▲' : '▾'}</span>
+      </button>
+      {open && (
+        <ul className="stale-manual-list">
+          {txns.map((tx) => (
+            <li key={tx.transaction_id} className="stale-manual-item">
+              <div className="stale-manual-item__info">
+                <span className="stale-manual-item__payee">{tx.payee || '(no payee)'}</span>
+                <span className="stale-manual-item__meta">{fmtDate(tx.date)} · {tx.account}</span>
+              </div>
+              <span className="stale-manual-item__amount">
+                {tx.outflow > 0 ? `-${fmt(tx.outflow)}` : `+${fmt(tx.inflow)}`}
+              </span>
+              <button className="stale-manual-item__delete" onClick={() => onDelete(tx)} title="Cancel transaction">
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function TypeSelectCard({ onSelect }: { onSelect: (type: TransactionType) => void }) {
   return (
     <div className="triage-card triage-card--type-select">
@@ -299,14 +340,23 @@ export default function Triage() {
   const allTxns = rawAllTxns ?? [];
   const categories = rawCategories ?? [];
 
-  // Unreviewed, non-split-child transactions, oldest-first
+  // Unreviewed, non-split-child, non-manual transactions, oldest-first.
+  // Manual transactions are pre-entered by the user and don't need triage unless stale.
   const triageQueue = useMemo(
     () =>
       allTxns
-        .filter((t) => !t.parent_id && !t.reviewed)
+        .filter((t) => !t.parent_id && !t.reviewed && t.status !== 'manual')
         .sort((a, b) => a.date.localeCompare(b.date)),
     [allTxns]
   );
+
+  // Manual transactions that haven't cleared in STALE_DAYS days
+  const staleManual = useMemo(() => {
+    const cutoff = staleCutoff();
+    return allTxns.filter(
+      (t) => t.status === 'manual' && !t.matched_id && t.date <= cutoff
+    );
+  }, [allTxns]);
 
   const [index, setIndex] = useState(0);
   const [selectedCategory, setSelectedCategory] = useState('');
@@ -361,6 +411,7 @@ export default function Triage() {
   if (index >= total) {
     return (
       <div className="screen triage-screen">
+        <StaleManualBanner txns={staleManual} onDelete={handleDeleteStaleManual} />
         <div className="triage-all-caught-up">
           <div className="triage-caught-up-emoji">🎉</div>
           <div className="triage-caught-up-text">All caught up!</div>
@@ -429,6 +480,21 @@ export default function Triage() {
     setSelectedCategory('');
   };
 
+  const handleDeleteStaleManual = useCallback(async (tx: Transaction) => {
+    if (!token) return;
+    if (!confirm(`Delete "${tx.payee || 'this transaction'}" (${tx.outflow > 0 ? fmt(tx.outflow) : fmt(tx.inflow)})?`)) return;
+    try {
+      // Remove from IndexedDB optimistically; also clear from sheet
+      await db.transactions.delete(tx.transaction_id);
+      const client = new SheetsClient(SHEET_ID, token);
+      // Clear the row by blanking the transaction_id column — keep row intact to avoid shifting
+      await client.updateValues(`Transactions!A${tx._rowIndex}`, [['']] );
+    } catch (e) {
+      if (e instanceof AuthError) { notifySessionExpired(); return; }
+      setError('Failed to delete — please try again');
+    }
+  }, [token, notifySessionExpired]);
+
   return (
     <div className="screen triage-screen">
       <header className="screen-header">
@@ -439,6 +505,8 @@ export default function Triage() {
           <button className="triage-nav-btn" onClick={advance} disabled={index >= total - 1}>›</button>
         </div>
       </header>
+
+      <StaleManualBanner txns={staleManual} onDelete={handleDeleteStaleManual} />
 
       <div className="triage-card-wrapper">
         {effectiveType === '' && (


### PR DESCRIPTION
## Summary

- Excludes `status='manual'` transactions from the Triage card queue — pre-entered transactions don't need re-triage since the user already classified them
- Adds a collapsible amber warning banner in Triage for manual transactions that haven't matched a cleared import in 14+ days, with a Delete action
- Banner appears both above the card stack and on the "all caught up" screen
- Nav badge now includes stale manual count alongside regular unreviewed count
- Adds `docs/USER_GUIDE.md` with a full Triage section and placeholder stubs for other screens
- Adds CLAUDE.md conventions: User Guide update rule per feature, generic import language rule

## Test plan

- [ ] Triage queue no longer shows `status='manual'` transactions in the card stack
- [ ] Amber banner appears when a manual transaction is >14 days old with no `matched_id`
- [ ] Banner is collapsed by default; expands to list affected transactions
- [ ] Delete removes the transaction from IndexedDB and blanks the sheet row
- [ ] Banner also visible on the "All caught up!" screen
- [ ] Nav badge count includes stale manual transactions
- [ ] No TypeScript errors (`npx tsc --noEmit`)
- [ ] Unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)